### PR TITLE
Fixing exception thrown when fail_when_locked is true

### DIFF
--- a/portalocker/utils.py
+++ b/portalocker/utils.py
@@ -83,15 +83,17 @@ class Lock(object):
 
                 # Try again
                 try:
-                    fh = self._get_lock(fh)
-
-                    # We've got the lock, now return an error if
-                    # fail_when_locked is True or break if not
+                    
+                    # We already tried to the get the lock
+                    # If fail_when_locked is true, then stop trying
                     if fail_when_locked:
-                        self._release_lock()
                         raise AlreadyLocked(*exception)
+
                     else:
+                        # We've got the lock
+                        fh = self._get_lock(fh)
                         break
+                    
                 except portalocker.LockException:
                     pass
 


### PR DESCRIPTION
Fixing exception "Lock object has no attribute '_release_lock'" when fail_when_locked is true due to the call to Lock._release_lock() which fails because _release_lock is not defined.

From what I can tell, portallocker is doing something wrong when it attempts to raise an AlreadyLocked when fail_when_locked is true.

Basically, the logic in acquire goes like this:
 1) Try to get the lock
 2) If you got an exception, loop until you get the lock
 3) In the loop: throw an exception if fail_when_locked is true (since we already tried once)

acquire() tries to obtain the lock in the while loop but instantly throws it away when fail_when_locked is true. It then tries to call _release_lock on the Lock object which doesn't exist.

I don't see why it tries to get the lock the second time (and why it then releases it instantly). Instead, it seems like it ought just bail in the while loop without trying to get the lock the second time if fail_when_locked is true since it already tried once and failed. Also, I don't see how Lock._release_lock() will ever work since it isn't defined.
