### PR TITLE
Use real time to calculate timeout

### DIFF
--- a/portalocker/utils.py
+++ b/portalocker/utils.py
@@ -7,6 +7,8 @@ from . import exceptions
 from . import constants
 from . import portalocker
 
+current_time = getattr(time, "monotonic", time.time)
+
 DEFAULT_TIMEOUT = 5
 DEFAULT_CHECK_INTERVAL = 0.25
 LOCK_METHOD = constants.LOCK_EX | constants.LOCK_NB
@@ -126,11 +128,11 @@ class Lock(object):
             # Try to lock
             fh = self._get_lock(fh)
         except exceptions.LockException as exception:
-            # Try till the timeout is 0
-            while timeout > 0:
+            # Try till the timeout has passed
+            timeoutend = current_time() + timeout
+            while timeoutend > current_time():
                 # Wait a bit
                 time.sleep(check_interval)
-                timeout -= check_interval
 
                 # Try again
                 try:

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -30,7 +30,8 @@ def test_with_timeout(tmpfile):
     with pytest.raises(portalocker.AlreadyLocked):
         with portalocker.Lock(tmpfile, timeout=0.1) as fh:
             print('writing some stuff to my cache...', file=fh)
-            with portalocker.Lock(tmpfile, timeout=0.1, mode='wb'):
+            with portalocker.Lock(tmpfile, timeout=0.1, mode='wb',
+                                  fail_when_locked=True):
                 pass
             print('writing more stuff to my cache...', file=fh)
 


### PR DESCRIPTION
When locking over a network, the locking operation can take some time.
This causes the timeout to take longer than expected.