### PR TITLE
Remove Python 2.6 (follow up to 87880158)

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,7 +8,6 @@ build: false  # Not a C# project, build stuff at the test step instead.
 
 test_script:
   - 'set TESTENVS=
-          py26,
           py27,
           py33,
           py34


### PR DESCRIPTION
This fixes tests on AppVeyor.