### PR TITLE
Allow for development setuptools

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,11 +4,11 @@ import os
 import sys
 import setuptools
 from setuptools.command.test import test as TestCommand
-from distutils.version import StrictVersion
+from distutils.version import LooseVersion
 from setuptools import __version__ as setuptools_version
 
 
-if StrictVersion(setuptools_version) < StrictVersion('38.3.0'):
+if LooseVersion(setuptools_version) < LooseVersion('38.3.0'):
     raise SystemExit(
         'Your `setuptools` version is old. '
         'Please upgrade setuptools by running `pip install -U setuptools` '
@@ -47,7 +47,7 @@ class PyTest(TestCommand):
         import pytest
         errno = pytest.main(shlex.split(self.pytest_args))
         sys.exit(errno)
-    
+
 
 class Combine(setuptools.Command):
     description = 'Build single combined portalocker file'


### PR DESCRIPTION
For non-standard release setuptools, the logic fails, for example `setuptools==41.4.0.post20191022` will create:

```
traceback (most recent call last):
  File "nix_run_setup", line 8, in <module>
    exec(compile(getattr(tokenize, 'open', open)(__file__).read().replace('\\r\\n', '\\n'), __file__, 'exec'))
  File "setup.py", line 11, in <module>
    if StrictVersion(setuptools_version) < StrictVersion('38.3.0'):
  File "/nix/store/zdh16dcvjw99ybam59zd2ijb6bx138j0-python3-3.7.5/lib/python3.7/distutils/version.py", line 40, in __init__
    self.parse(vstring)
  File "/nix/store/zdh16dcvjw99ybam59zd2ijb6bx138j0-python3-3.7.5/lib/python3.7/distutils/version.py", line 137, in parse
    raise ValueError("invalid version number '%s'" % vstring)
ValueError: invalid version number '41.4.0.post20191022'
```