### PR TITLE
Fix ResourceWarning 'unclosed file' if LockException is raised

### DIFF
--- a/portalocker/utils.py
+++ b/portalocker/utils.py
@@ -153,6 +153,7 @@ class Lock(object):
                     pass
 
             else:
+                fh.close()                
                 # We got a timeout... reraising
                 raise exceptions.LockException(exception)
 

--- a/portalocker/utils.py
+++ b/portalocker/utils.py
@@ -153,7 +153,7 @@ class Lock(object):
                     pass
 
             else:
-                fh.close()                
+                fh.close()
                 # We got a timeout... reraising
                 raise exceptions.LockException(exception)
 


### PR DESCRIPTION
Fixes ResourceWarning 'unclosed file' if LockException is raised

The following warning is raised:
ResourceWarning: unclosed file
Object allocated at (most recent call last):
  File "portalocker\utils.py", lineno 174
    return open(self.filename, self.mode, **self.file_open_kwargs)