### PR TITLE
Remove Python 2 classifier

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -113,7 +113,6 @@ if __name__ == '__main__':
         classifiers=[
             'Intended Audience :: Developers',
             'Programming Language :: Python',
-            'Programming Language :: Python :: 2.7',
             'Programming Language :: Python :: 3.3',
             'Programming Language :: Python :: 3.4',
             'Programming Language :: Python :: 3.5',


### PR DESCRIPTION
This change should have been included in Portalocker 2.0.0 release. If we removed it at that time, it might have prevented Python 2.x environments from incorrectly pulling in an incompatible Portalocker 2.x and causing failure. (The [MSAL Extensions' build pipeline currently runs into such a problem](https://github.com/AzureAD/microsoft-authentication-extensions-for-python/pull/95), I'll find a workaround for it, but it would still be good to make the following change here.)