### PR TITLE
Explicitly mentions Semantic Versioning

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -196,6 +196,13 @@ portalocker.exceptions.AlreadyLocked
 More examples can be found in the
 `tests <http://portalocker.readthedocs.io/en/latest/_modules/tests/tests.html>`_.
 
+
+Versioning
+----------
+
+This library follows `Semantic Versioning <http://semver.org/>`_.
+
+
 Changelog
 ---------
 


### PR DESCRIPTION
My [observation](https://github.com/AzureAD/microsoft-authentication-extensions-for-python/issues/94) is this portalocker library is already using [Semantic Versioning](http://semver.org/). If that is the case, shall we explicitly mention it in the README?

And, I hope this PR will also update the [portalocker docs](https://portalocker.readthedocs.io/en/latest/).