### PR TITLE
Actually regulate the Python version requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -120,6 +120,7 @@ if __name__ == '__main__':
             'Programming Language :: Python :: Implementation :: CPython',
             'Programming Language :: Python :: Implementation :: PyPy',
         ],
+        python_requires=">=3.3",
         keywords='locking, locks, with statement, windows, linux, unix',
         author=about['__author__'],
         author_email=about['__email__'],


### PR DESCRIPTION
This one is the missing piece of #67.

Note:
1. I anticipate, after a new portalocker 2.3.2 with this PR being released, downstream projects' Python 2 environment should not pick up portalocker 2.3.2, then it would mean this PR works. I am willing to help you test that behavior in the downstream project MSAL Extensions.
2. However, even (1) would happen, the downstream project's Python 2 environment might still pull in the earlier version which is portalocker 2.3.1, which would still fail. At this point, there is probably no way to fix it from within Portalocker. I'll have to explicitly exclude portalocker 2.0.0 - 2.3.1 range from my project.
3. Even so, I still consider (1) is conceptually the right thing to do. So, this PR is still worthy.