### PR TITLE
`README.rst`: Trim outdated `.EXCLUSIVE` snippets

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -123,38 +123,6 @@ To customize the opening and locking a manual approach is also possible:
 
 >>> import portalocker
 >>> file = open('somefile', 'r+')
->>> portalocker.lock(file, portalocker.EXCLUSIVE)
->>> file.seek(12)
->>> file.write('foo')
->>> file.close()
-
-Explicitly unlocking is not needed in most cases but omitting it has been known
-to cause issues:
-
->>> import portalocker
->>> with portalocker.Lock('somefile', timeout=1) as fh:
-...     print >>fh, 'writing some stuff to my cache...'
-
-To customize the opening and locking a manual approach is also possible:
-
->>> import portalocker
->>> file = open('somefile', 'r+')
->>> portalocker.lock(file, portalocker.EXCLUSIVE)
->>> file.seek(12)
->>> file.write('foo')
->>> file.close()
-
-Explicitly unlocking is not needed in most cases but omitting it has been known
-to cause issues:
-
->>> import portalocker
->>> with portalocker.Lock('somefile', timeout=1) as fh:
-...     print >>fh, 'writing some stuff to my cache...'
-
-To customize the opening and locking a manual approach is also possible:
-
->>> import portalocker
->>> file = open('somefile', 'r+')
 >>> portalocker.lock(file, portalocker.LOCK_EX)
 >>> file.seek(12)
 >>> file.write('foo')


### PR DESCRIPTION
I was following the documentation for this project for the first time, but this section confused me a little. It looks like these bits of the documentation got duplicated somehow?

I've kept only the `portalocker.LOCK_EX` snippet, since it seems to be the only valid flag presently.