### PR TITLE
BoundedSemaphore: do not fail if fail_when_locked is False

### DIFF
--- a/portalocker/utils.py
+++ b/portalocker/utils.py
@@ -425,7 +425,9 @@ class BoundedSemaphore(LockBase):
             if self.try_lock(filenames):  # pragma: no branch
                 return self.lock  # pragma: no cover
 
-        raise exceptions.AlreadyLocked()
+        if fail_when_locked:
+            raise exceptions.AlreadyLocked()
+        return None
 
     def try_lock(self, filenames: typing.Sequence[Filename]) -> bool:
         filename: Filename


### PR DESCRIPTION
Hi there!

It is misleading that a BoundedSemaphore fails regardless of `fail_when_locked`. This PR proposes to fix this.

Thanks!
Flavien