### PR TITLE
Add support for Python 3.11 and drop EOL 3.5-3.7

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -17,7 +17,7 @@ jobs:
         os: ['macos-latest', 'windows-latest']
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4
         with:
@@ -41,9 +41,9 @@ jobs:
         python-version: ['3.8', '3.9', '3.10', '3.11']
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Start Redis
-      uses: supercharge/redis-github-action@1.4.0
+      uses: supercharge/redis-github-action@1.7.0
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v4
       with:

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.8', '3.9', '3.10']
+        python-version: ['3.8', '3.9', '3.10', '3.11']
         os: ['macos-latest', 'windows-latest']
 
     steps:
@@ -38,7 +38,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.8', '3.9', '3.10']
+        python-version: ['3.8', '3.9', '3.10', '3.11']
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ develop ]
 
+env:
+  FORCE_COLOR: 1
+
 jobs:
   # Run os specific tests on the slower OS X/Windows machines
   windows_osx:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,6 +9,8 @@ environment:
   - TOXENV: py37
   - TOXENV: py38
   - TOXENV: py39
+  - TOXENV: py310
+  - TOXENV: py311
 
 install:
   - "%PYTHON% -m pip install -U tox setuptools wheel"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,7 +5,6 @@ environment:
   global:
     PYTHON: "C:\\Python38-x64\\python.exe"
   matrix:
-  - TOXENV: py36
   - TOXENV: py37
   - TOXENV: py38
   - TOXENV: py39

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,7 +5,6 @@ environment:
   global:
     PYTHON: "C:\\Python38-x64\\python.exe"
   matrix:
-  - TOXENV: py37
   - TOXENV: py38
   - TOXENV: py39
   - TOXENV: py310

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Documentation build configuration file, created by
 # sphinx-quickstart on Thu Feb 27 20:00:23 2014.
@@ -57,7 +56,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = metadata.__package_name__.replace('-', ' ').capitalize()
-copyright = u'%s,  <a href="http://wol.ph/">%s</a>' % (
+copyright = '{},  <a href="http://wol.ph/">{}</a>'.format(
     datetime.date.today().year,
     metadata.__author__,
 )
@@ -213,7 +212,7 @@ htmlhelp_basename = metadata.__package_name__ + '-doc'
 latex_documents = [(
     'index',
     '%s.tex' % metadata.__package_name__,
-    u'%s Documentation' % metadata.__package_name__.replace('-', ' ').capitalize(),
+    '%s Documentation' % metadata.__package_name__.replace('-', ' ').capitalize(),
    metadata.__author__,
    'manual',
 )]
@@ -246,7 +245,7 @@ latex_documents = [(
 man_pages = [(
     'index',
     metadata.__package_name__,
-    u'%s Documentation' % metadata.__package_name__.replace('-', ' ').capitalize(),
+    '%s Documentation' % metadata.__package_name__.replace('-', ' ').capitalize(),
     [metadata.__author__],
     1,
 )]
@@ -263,7 +262,7 @@ man_pages = [(
 texinfo_documents = [(
     'index',
     metadata.__package_name__,
-    u'%s Documentation' % metadata.__package_name__.replace('-', ' ').capitalize(),
+    '%s Documentation' % metadata.__package_name__.replace('-', ' ').capitalize(),
     metadata.__author__,
     metadata.__package_name__,
     metadata.__description__,

--- a/portalocker/portalocker.py
+++ b/portalocker/portalocker.py
@@ -81,7 +81,7 @@ if os.name == 'nt':  # pragma: no cover
             finally:
                 if savepos:
                     file_.seek(savepos)
-        except IOError as exc:
+        except OSError as exc:
             raise exceptions.LockException(
                 exceptions.LockException.LOCK_FAILED, exc.strerror,
                 fh=file_

--- a/portalocker/redis.py
+++ b/portalocker/redis.py
@@ -100,9 +100,9 @@ class RedisLock(utils.LockBase):
         for key, value in self.DEFAULT_REDIS_KWARGS.items():
             self.redis_kwargs.setdefault(key, value)
 
-        super(RedisLock, self).__init__(timeout=timeout,
-                                        check_interval=check_interval,
-                                        fail_when_locked=fail_when_locked)
+        super().__init__(timeout=timeout,
+                         check_interval=check_interval,
+                         fail_when_locked=fail_when_locked)
 
     def get_connection(self) -> client.Redis:
         if not self.connection:

--- a/portalocker/utils.py
+++ b/portalocker/utils.py
@@ -320,8 +320,8 @@ class RLock(Lock):
             self, filename, mode='a', timeout=DEFAULT_TIMEOUT,
             check_interval=DEFAULT_CHECK_INTERVAL, fail_when_locked=False,
             flags=LOCK_METHOD):
-        super(RLock, self).__init__(filename, mode, timeout, check_interval,
-                                    fail_when_locked, flags)
+        super().__init__(filename, mode, timeout, check_interval,
+                         fail_when_locked, flags)
         self._acquire_count = 0
 
     def acquire(
@@ -330,8 +330,8 @@ class RLock(Lock):
         if self._acquire_count >= 1:
             fh = self.fh
         else:
-            fh = super(RLock, self).acquire(timeout, check_interval,
-                                            fail_when_locked)
+            fh = super().acquire(timeout, check_interval,
+                                 fail_when_locked)
         self._acquire_count += 1
         assert fh
         return fh
@@ -342,7 +342,7 @@ class RLock(Lock):
                 "Cannot release more times than acquired")
 
         if self._acquire_count == 1:
-            super(RLock, self).release()
+            super().release()
         self._acquire_count -= 1
 
 

--- a/portalocker_tests/tests.py
+++ b/portalocker_tests/tests.py
@@ -1,6 +1,3 @@
-from __future__ import print_function
-from __future__ import with_statement
-
 import os
 import dataclasses
 import multiprocessing
@@ -173,12 +170,12 @@ def test_exlusive(tmpfile):
     with open(tmpfile, 'w') as fh:
         fh.write('spam and eggs')
 
-    fh = open(tmpfile, 'r')
+    fh = open(tmpfile)
     portalocker.lock(fh, portalocker.LOCK_EX | portalocker.LOCK_NB)
 
     # Make sure we can't read the locked file
     with pytest.raises(portalocker.LockException):
-        with open(tmpfile, 'r') as fh2:
+        with open(tmpfile) as fh2:
             portalocker.lock(fh2, portalocker.LOCK_EX | portalocker.LOCK_NB)
             fh2.read()
 
@@ -197,11 +194,11 @@ def test_shared(tmpfile):
     with open(tmpfile, 'w') as fh:
         fh.write('spam and eggs')
 
-    f = open(tmpfile, 'r')
+    f = open(tmpfile)
     portalocker.lock(f, portalocker.LOCK_SH | portalocker.LOCK_NB)
 
     # Make sure we can read the locked file
-    with open(tmpfile, 'r') as fh2:
+    with open(tmpfile) as fh2:
         portalocker.lock(fh2, portalocker.LOCK_SH | portalocker.LOCK_NB)
         assert fh2.read() == 'spam and eggs'
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,9 +1,6 @@
 [metadata]
 description_file = README.rst
 
-[bdist_wheel]
-universal = 1
-
 [flake8]
 ignore =
     W391,E303,W503

--- a/setup.py
+++ b/setup.py
@@ -93,6 +93,7 @@ if __name__ == '__main__':
             'Programming Language :: Python :: 3.8',
             'Programming Language :: Python :: 3.9',
             'Programming Language :: Python :: 3.10',
+            'Programming Language :: Python :: 3.11',
             'Programming Language :: Python :: Implementation :: CPython',
             'Programming Language :: Python :: Implementation :: PyPy',
         ],

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 import os
 import re
 import typing

--- a/setup.py
+++ b/setup.py
@@ -87,8 +87,6 @@ if __name__ == '__main__':
         classifiers=[
             'Intended Audience :: Developers',
             'Programming Language :: Python',
-            'Programming Language :: Python :: 3.5',
-            'Programming Language :: Python :: 3.6',
             'Programming Language :: Python :: 3.7',
             'Programming Language :: Python :: 3.8',
             'Programming Language :: Python :: 3.9',
@@ -97,7 +95,7 @@ if __name__ == '__main__':
             'Programming Language :: Python :: Implementation :: CPython',
             'Programming Language :: Python :: Implementation :: PyPy',
         ],
-        python_requires='>=3.5',
+        python_requires='>=3.7',
         keywords='locking, locks, with statement, windows, linux, unix',
         author=about['__author__'],
         author_email=about['__email__'],

--- a/setup.py
+++ b/setup.py
@@ -85,7 +85,6 @@ if __name__ == '__main__':
         classifiers=[
             'Intended Audience :: Developers',
             'Programming Language :: Python',
-            'Programming Language :: Python :: 3.7',
             'Programming Language :: Python :: 3.8',
             'Programming Language :: Python :: 3.9',
             'Programming Language :: Python :: 3.10',
@@ -93,7 +92,7 @@ if __name__ == '__main__':
             'Programming Language :: Python :: Implementation :: CPython',
             'Programming Language :: Python :: Implementation :: PyPy',
         ],
-        python_requires='>=3.7',
+        python_requires='>=3.8',
         keywords='locking, locks, with statement, windows, linux, unix',
         author=about['__author__'],
         author_email=about['__email__'],

--- a/tox.ini
+++ b/tox.ini
@@ -3,6 +3,8 @@ envlist = py38, py39, py310, py311, pypy3, flake8, docs
 skip_missing_interpreters = True
 
 [testenv]
+pass_env =
+    FORCE_COLOR
 basepython =
     py38: python3.8
     py39: python3.9


### PR DESCRIPTION
Python 3.11 was [released on 2022-10-24](https://discuss.python.org/t/python-3-11-0-final-is-now-available/20291?u=hugovk) 🚀 

[![image](https://user-images.githubusercontent.com/1324225/198233993-5b79523b-370f-4316-a4be-9403c8209068.png)](https://discuss.python.org/t/python-3-11-0-final-is-now-available/20291?u=hugovk)

---

Python 3.5-3.7 are EOL and no longer receiving security updates (or any updates) from the core Python team.

<img width="764" alt="image" src="https://github.com/wolph/portalocker/assets/1324225/9bfb6720-b532-4a6b-81c1-b5b0bee918f0">

https://devguide.python.org/versions/


