### PR TITLE
Support for fcntl.lockf (and some minor bugfixes)

### DIFF
--- a/portalocker/portalocker.py
+++ b/portalocker/portalocker.py
@@ -90,6 +90,11 @@ elif os.name == 'posix':  # pragma: no cover
     import fcntl
     import errno
 
+    # The locking implementation.
+    # Expected values are either fcntl.flock() or fcntl.lockf(),
+    # but any callable that matches the syntax will be accepted.
+    LOCKER = fcntl.flock
+
     def lock(file_: typing.Union[typing.IO, int], flags: LockFlags):
         # Locking with NON_BLOCKING without EXCLUSIVE or SHARED enabled results
         # in an error
@@ -102,7 +107,7 @@ elif os.name == 'posix':  # pragma: no cover
             )
 
         try:
-            fcntl.flock(file_, flags)
+            LOCKER(file_, flags)
         except OSError as exc_value:
             # Python can use one of several different exception classes to represent
             # timeout (most likely is BlockingIOError and IOError), but these errors
@@ -117,7 +122,8 @@ elif os.name == 'posix':  # pragma: no cover
                 raise
 
     def unlock(file_: typing.IO):
-        fcntl.flock(file_.fileno(), LockFlags.UNBLOCK)
+        LOCKER(file_.fileno(), LockFlags.UNBLOCK)
+
 
 else:  # pragma: no cover
     raise RuntimeError('PortaLocker only defined for nt and posix platforms')

--- a/portalocker/portalocker.py
+++ b/portalocker/portalocker.py
@@ -117,8 +117,13 @@ elif os.name == 'posix':  # pragma: no cover
             # and check the errno (which should be EACCESS or EAGAIN according to the
             # spec).
             if exc_value.errno in (errno.EACCES, errno.EAGAIN):
+                # A timeout exception, wrap this so the outer code knows to try again
+                # (if it wants to).
+                # TODO: Would AlreadyLocked by a better error to raise here? Or perhaps
+                # a new exception class like TryAgain?
                 raise exceptions.LockException(exc_value, fh=file_) from exc_value
             else:
+                # Something else went wrong; don't wrap this so we stop immediately.
                 raise
 
     def unlock(file_: typing.IO):

--- a/portalocker/utils.py
+++ b/portalocker/utils.py
@@ -281,8 +281,13 @@ class Lock(LockBase):
                 if fail_when_locked:
                     try_close()
                     raise exceptions.AlreadyLocked(exception) from exc
+            except Exception as exc:
+                # Something went wrong with the locking mechanism.
+                # Wrap in a LockException and re-raise:
+                try_close()
+                raise exceptions.LockException(exc) from exc
 
-                # Wait a bit
+            # Wait a bit
 
         if exception:
             try_close()

--- a/portalocker/utils.py
+++ b/portalocker/utils.py
@@ -287,7 +287,7 @@ class Lock(LockBase):
         if exception:
             try_close()
             # We got a timeout... reraising
-            raise exceptions.LockException(exception)
+            raise exception
 
         # Prepare the filehandle (truncate if needed)
         fh = self._prepare_fh(fh)

--- a/portalocker_tests/tests.py
+++ b/portalocker_tests/tests.py
@@ -163,11 +163,11 @@ def test_exlusive(tmpfile):
     with open(tmpfile, 'w') as fh:
         fh.write('spam and eggs')
 
-    with open(tmpfile) as fh:
+    with open(tmpfile, "w") as fh:
         portalocker.lock(fh, portalocker.LOCK_EX | portalocker.LOCK_NB)
 
         # Make sure we can't read the locked file
-        with pytest.raises(portalocker.LockException), open(tmpfile) as fh2:
+        with pytest.raises(portalocker.LockException), open(tmpfile, "r+") as fh2:
             portalocker.lock(fh2, portalocker.LOCK_EX | portalocker.LOCK_NB)
             fh2.read()
 
@@ -211,10 +211,10 @@ def test_blocking_timeout(tmpfile):
     flags = LockFlags.SHARED
 
     with pytest.warns(UserWarning):
-        with portalocker.Lock(tmpfile, timeout=5, flags=flags):
+        with portalocker.Lock(tmpfile, "a+", timeout=5, flags=flags):
             pass
 
-    lock = portalocker.Lock(tmpfile, flags=flags)
+    lock = portalocker.Lock(tmpfile, "a+", flags=flags)
     with pytest.warns(UserWarning):
         lock.acquire(timeout=5)
 
@@ -330,9 +330,9 @@ def test_exclusive_processes(tmpfile, fail_when_locked):
     reason='Locking on Windows requires a file object',
 )
 def test_lock_fileno(tmpfile):
-    with open(tmpfile, 'a') as a:
-        with open(tmpfile, 'a') as b:
-            # Lock exclusive non-blocking
+    with open(tmpfile, 'a+') as a:
+        with open(tmpfile, 'a+') as b:
+            # Lock shared non-blocking
             flags = LockFlags.SHARED | LockFlags.NON_BLOCKING
 
             # First lock file a


### PR DESCRIPTION
Hi there, thanks for the nice code!

This PR is a small extension that adds support for both the `flock` and `lockf` mechanisms under linux. Apologies for not discussing first, I often find it easier to discuss potential changes with some code to look at. If this extension is not a good fit for the project, let me know and I can maintain elsewhere. There are also a few bugfixes included relating to exception handling, I'll annotate in the code why I included these. If you'd just like the bugfixes (or prefer to have them in a separate PR) I can strip them out.

The `lockf` and `flock` interfaces can be toggled through a new module level attribute, `portalocker.portalocker.LOCKER`. Its default value is `portalocker.portalocker.LOCKER = fcntl.flock` (to maintain backwards compatibility). The lockf interface can instead be chosen by doing:
```
import portalocker.portalocker
import fcntl
portalocker.portalocker.LOCKER = fcntl.lockf
```

The rest of the package can then be used as normal (except of course for the important differences between lockf and flock). This isn't the most elegant way of choosing the locking implementation, but it was the easiest fit with the current package design. Please note that this will have the 'side-effect' of changing the behaviour of other parts of the package that depend on the locking implementation, eg `BoundedSemaphore` and `NamedBoundedSemaphore`. When using lockf, I'm pretty sure neither semaphore will function in a multi-threaded context (because lockf always allows the same process to acquire a new lock on the same file, even if opened with a new filehandle), but this is due to the way in which `lockf` is implemented at the OS level, rather than a problem with the python code.

As an aside, this PR is probably a fix for #92, as `flock` is famously less reliable over NFS and other network file systems than `lockf`.