### PR TITLE
Include missing typehints (mostly function return value typehints)

### DIFF
--- a/portalocker/__main__.py
+++ b/portalocker/__main__.py
@@ -90,7 +90,7 @@ def _read_file(
             yield _clean_line(line, names)
 
 
-def _clean_line(line: str, names: set[str]):
+def _clean_line(line: str, names: set[str]) -> str:
     # Replace `some_import.spam` with `spam`
     if names:
         joined_names = '|'.join(names)
@@ -100,7 +100,7 @@ def _clean_line(line: str, names: set[str]):
     return _USELESS_ASSIGNMENT_RE.sub('', line)
 
 
-def combine(args: argparse.Namespace):
+def combine(args: argparse.Namespace) -> None:
     output_file = args.output_file
     pathlib.Path(output_file.name).parent.mkdir(parents=True, exist_ok=True)
 

--- a/portalocker/portalocker.py
+++ b/portalocker/portalocker.py
@@ -26,7 +26,7 @@ if os.name == 'nt':  # pragma: no cover
 
     __overlapped = pywintypes.OVERLAPPED()
 
-    def lock(file_: typing.IO | int, flags: LockFlags):
+    def lock(file_: typing.IO | int, flags: LockFlags) -> None:
         # Windows locking does not support locking through `fh.fileno()` so
         # we cast it to make mypy and pyright happy
         file_ = typing.cast(typing.IO, file_)
@@ -64,7 +64,7 @@ if os.name == 'nt':  # pragma: no cover
             if savepos:
                 file_.seek(savepos)
 
-    def unlock(file_: typing.IO):
+    def unlock(file_: typing.IO) -> None:
         try:
             savepos = file_.tell()
             if savepos:
@@ -102,7 +102,7 @@ elif os.name == 'posix':  # pragma: no cover
     # but any callable that matches the syntax will be accepted.
     LOCKER = fcntl.flock  # pyright: ignore[reportConstantRedefinition]
 
-    def lock(file: int | types.IO, flags: LockFlags):  # type: ignore[misc]
+    def lock(file: int | types.IO, flags: LockFlags) -> None:  # type: ignore[misc]
         assert LOCKER is not None, 'We need a locking function in `LOCKER` '
         # Locking with NON_BLOCKING without EXCLUSIVE or SHARED enabled
         # results in an error
@@ -146,7 +146,7 @@ elif os.name == 'posix':  # pragma: no cover
                 fh=file,
             ) from exc_value
 
-    def unlock(file: types.IO):  # type: ignore[misc]
+    def unlock(file: types.IO) -> None:  # type: ignore[misc]
         assert LOCKER is not None, 'We need a locking function in `LOCKER` '
         LOCKER(file.fileno(), LockFlags.UNBLOCK)
 

--- a/portalocker/redis.py
+++ b/portalocker/redis.py
@@ -87,7 +87,7 @@ class RedisLock(utils.LockBase):
         thread_sleep_time: float = DEFAULT_THREAD_SLEEP_TIME,
         unavailable_timeout: float = DEFAULT_UNAVAILABLE_TIMEOUT,
         redis_kwargs: dict[str, typing.Any] | None = None,
-    ):
+    ) -> None:
         # We don't want to close connections given as an argument
         self.close_connection = not connection
 
@@ -131,7 +131,7 @@ class RedisLock(utils.LockBase):
         self.connection.publish(data['response_channel'], str(time.time()))
 
     @property
-    def client_name(self):
+    def client_name(self) -> str:
         return f'{self.channel}-lock'
 
     def acquire(  # type: ignore[override]
@@ -201,7 +201,7 @@ class RedisLock(utils.LockBase):
         self,
         connection: redis.client.Redis[str],
         timeout: float,
-    ):
+    ) -> bool | None:
         # Random channel name to get messages back from the lock
         response_channel = f'{self.channel}-{random.random()}'
 
@@ -234,7 +234,7 @@ class RedisLock(utils.LockBase):
                 )
         return None
 
-    def release(self):
+    def release(self) -> None:
         if self.thread:  # pragma: no branch
             self.thread.stop()
             self.thread.join()


### PR DESCRIPTION
Hey! Thank you very much for creating this library. I'd like to start using this library productively, but unfortunately, for quite a lot of functions, a return value type hint seems to be missing, especially when it's `None`.

Note that although `pyright` will assume `None` as the return type hint when the function is missing one, `mypy` will assume (more rightly, if I may add) `Any`, but also throw you an error if you're using `mypy` in "strict" mode (which one should, IMHO).

For example, this code
```
import portalocker

lock = portalocker.RedisLock("test123")
lock.acquire()
name = lock.client_name
lock.release()
```
will lead to `mypy` errors such as:
```
prtlck.py:6: error: Call to untyped function "release" in typed context  [no-untyped-call]
```

In this PR, I added function return value typehints to all functions I could find where this is missing.