### PR TITLE
Add split-inode waiter regression for #115

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -23,7 +23,7 @@
  * Fixed a ``TemporaryFileLock``/``PidFileLock`` unlock-then-unlink race that
    could let two processes hold the same lock (split-brain); release now
    unlinks before unlocking on POSIX and acquire re-verifies file identity
-   (inode) after locking
+   (inode) after locking (#115)
  * Fixed ``BoundedSemaphore`` staying permanently "Already locked" after a
    non-contention error (e.g. a missing directory)
  * Fixed ``RedisLock`` crashed-holder detection: the liveness check was
@@ -48,7 +48,7 @@
  * ``TemporaryFileLock.release()`` and ``PidFileLock.release()`` are now
    no-ops when the object does not hold the lock, so a stale object (double
    release, or garbage collection of a failed acquire) can no longer unlink
-   the lock file out from under the current holder (#115)
+   the lock file out from under the current holder
  * ``TemporaryFileLock`` no longer keeps a strong ``atexit`` reference to
    itself, so unused instances can be garbage collected; cleanup at
    interpreter exit still happens via a weak reference
@@ -122,4 +122,3 @@ https://github.com/WoLpH/portalocker/commits/master
 0.1:
 
  * Initial release
-

--- a/docs/superpowers/plans/2026-07-16-issue-115-inode-waiters-plan.md
+++ b/docs/superpowers/plans/2026-07-16-issue-115-inode-waiters-plan.md
@@ -36,6 +36,7 @@ Add imports and helpers to `portalocker_tests/test_multiprocess.py`:
 
 ```python
 import multiprocessing.context
+import multiprocessing.process
 import multiprocessing.queues
 import pathlib
 import typing
@@ -80,7 +81,7 @@ def hold_inode_waiter(
     opened_event: multiprocessing.synchronize.Event,
     acquired_event: multiprocessing.synchronize.Event,
     release_event: multiprocessing.synchronize.Event,
-    inode_queue: multiprocessing.queues.Queue,
+    inode_queue: multiprocessing.queues.Queue[int],
 ) -> None:
     """Open the original inode, acquire, report it, and hold the lock."""
     original_get_fh: typing.Callable[
@@ -131,7 +132,7 @@ def test_temporary_lock_waiters_converge_on_current_inode(
     lock_kind: LockKind,
 ) -> None:
     """#115: waiters must reject an obsolete unlinked lock inode."""
-    context: multiprocessing.context.BaseContext = multiprocessing.get_context(
+    context: multiprocessing.context.SpawnContext = multiprocessing.get_context(
         'spawn'
     )
     filename: str = str(tmp_path / f'{lock_kind}.lock')
@@ -145,8 +146,8 @@ def test_temporary_lock_waiters_converge_on_current_inode(
     opened_event: multiprocessing.synchronize.Event = context.Event()
     acquired_event: multiprocessing.synchronize.Event = context.Event()
     release_event: multiprocessing.synchronize.Event = context.Event()
-    inode_queue: multiprocessing.queues.Queue = context.Queue()
-    waiter: multiprocessing.Process = context.Process(
+    inode_queue: multiprocessing.queues.Queue[int] = context.Queue()
+    waiter: multiprocessing.process.BaseProcess = context.Process(
         target=hold_inode_waiter,
         args=(
             filename,

--- a/docs/superpowers/plans/2026-07-16-issue-115-inode-waiters-plan.md
+++ b/docs/superpowers/plans/2026-07-16-issue-115-inode-waiters-plan.md
@@ -1,0 +1,392 @@
+# Issue 115 Inode Waiters Implementation Plan
+
+**For agentic workers:** REQUIRED SUB-SKILL: Use
+superpowers:subagent-driven-development (recommended) or
+superpowers:executing-plans to implement this plan task-by-task. Steps use
+checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Prove that POSIX temporary-file and PID-file waiters cannot return
+while holding an obsolete inode, while preserving portalocker 3.3.0 file
+lifecycle behavior.
+
+**Architecture:** Keep the existing post-acquisition inode validation in
+`TemporaryFileLock._acquire_verified()`. Add an event-driven multiprocessing
+regression that forces a waiter to open the holder's inode before release,
+then verifies a third actor cannot acquire and the waiter owns the inode named
+by the current path. Cover `TemporaryFileLock` and the `PidFileLock` sidecar
+through one parameterized test; change production code only if this test
+exposes a remaining violation.
+
+**Tech Stack:** Python 3.10+, `multiprocessing`, pytest, portalocker's existing
+`Lock`/`TemporaryFileLock`/`PidFileLock` APIs, uv, ruff, mypy, basedpyright,
+pyrefly, ty, and codespell.
+
+---
+
+### Task 1: Add the split-inode multiprocessing regression
+
+**Files:**
+
+- Modify: `portalocker_tests/test_multiprocess.py`
+- Inspect only unless the regression exposes a defect: `portalocker/utils.py`
+
+- [ ] **Step 1: Add typed, spawn-safe test helpers and the parameterized regression**
+
+Add imports and helpers to `portalocker_tests/test_multiprocess.py`:
+
+```python
+import multiprocessing.context
+import multiprocessing.queues
+import pathlib
+import typing
+from unittest import mock
+
+from portalocker import LockFlags, utils
+
+LockKind: typing.TypeAlias = typing.Literal['temporary', 'pid']
+
+
+def make_temporary_lock(
+    filename: str,
+    lock_kind: LockKind,
+    *,
+    timeout: float,
+    fail_when_locked: bool,
+) -> portalocker.TemporaryFileLock:
+    """Create one of the temporary-path lock implementations under test."""
+    lock_type: type[portalocker.TemporaryFileLock]
+    if lock_kind == 'temporary':
+        lock_type = portalocker.TemporaryFileLock
+    else:
+        lock_type = portalocker.PidFileLock
+    return lock_type(
+        filename,
+        timeout=timeout,
+        fail_when_locked=fail_when_locked,
+    )
+
+
+def native_lock_path(filename: str, lock_kind: LockKind) -> str:
+    """Return the pathname carrying the native OS lock."""
+    if lock_kind == 'pid':
+        return f'{filename}.lock'
+    return filename
+
+
+def hold_inode_waiter(
+    filename: str,
+    lock_kind: LockKind,
+    native_filename: str,
+    opened_event: multiprocessing.synchronize.Event,
+    acquired_event: multiprocessing.synchronize.Event,
+    release_event: multiprocessing.synchronize.Event,
+    inode_queue: multiprocessing.queues.Queue,
+) -> None:
+    """Open the original inode, acquire, report it, and hold the lock."""
+    original_get_fh: typing.Callable[
+        [utils.Lock],
+        typing.IO[typing.Any],
+    ] = typing.cast(
+        typing.Callable[[utils.Lock], typing.IO[typing.Any]],
+        utils.Lock._get_fh,
+    )
+
+    def announce_open(lock: utils.Lock) -> typing.IO[typing.Any]:
+        fh: typing.IO[typing.Any] = original_get_fh(lock)
+        if lock.filename == native_filename:
+            opened_event.set()
+        return fh
+
+    lock: portalocker.TemporaryFileLock = make_temporary_lock(
+        filename,
+        lock_kind,
+        timeout=30,
+        fail_when_locked=False,
+    )
+    try:
+        with mock.patch.object(utils.Lock, '_get_fh', announce_open):
+            fh: typing.IO[typing.Any] = lock.acquire()
+        inode_queue.put(os.fstat(fh.fileno()).st_ino)
+        acquired_event.set()
+        if not release_event.wait(timeout=30):
+            raise TimeoutError('parent did not release the inode waiter')
+    finally:
+        lock.release()
+```
+
+Add the regression after the existing multiprocessing tests:
+
+```python
+@pytest.mark.parametrize('lock_kind', ['temporary', 'pid'])
+@pytest.mark.skipif(
+    os.name == 'nt',
+    reason='POSIX-only inode replacement race',
+)
+@pytest.mark.skipif(
+    'pypy' in platform.python_implementation().lower(),
+    reason='pypy3 does not support the multiprocessing test',
+)
+def test_temporary_lock_waiters_converge_on_current_inode(
+    tmp_path: pathlib.Path,
+    lock_kind: LockKind,
+) -> None:
+    """#115: waiters must reject an obsolete unlinked lock inode."""
+    context: multiprocessing.context.BaseContext = multiprocessing.get_context(
+        'spawn'
+    )
+    filename: str = str(tmp_path / f'{lock_kind}.lock')
+    native_filename: str = native_lock_path(filename, lock_kind)
+    holder: portalocker.TemporaryFileLock = make_temporary_lock(
+        filename,
+        lock_kind,
+        timeout=30,
+        fail_when_locked=False,
+    )
+    opened_event: multiprocessing.synchronize.Event = context.Event()
+    acquired_event: multiprocessing.synchronize.Event = context.Event()
+    release_event: multiprocessing.synchronize.Event = context.Event()
+    inode_queue: multiprocessing.queues.Queue = context.Queue()
+    waiter: multiprocessing.Process = context.Process(
+        target=hold_inode_waiter,
+        args=(
+            filename,
+            lock_kind,
+            native_filename,
+            opened_event,
+            acquired_event,
+            release_event,
+            inode_queue,
+        ),
+    )
+    holder_released: bool = False
+
+    holder.acquire()
+    waiter.start()
+    try:
+        assert opened_event.wait(timeout=30), (
+            'waiter never opened the holder inode'
+        )
+        holder.release()
+        holder_released = True
+        assert acquired_event.wait(timeout=30), 'waiter never acquired'
+
+        waiter_inode: int = inode_queue.get(timeout=30)
+        contender: portalocker.TemporaryFileLock = make_temporary_lock(
+            filename,
+            lock_kind,
+            timeout=0,
+            fail_when_locked=True,
+        )
+        try:
+            with pytest.raises(portalocker.AlreadyLocked):
+                contender.acquire()
+        finally:
+            contender.release()
+
+        current_inode: int = os.stat(native_filename).st_ino
+        assert waiter_inode == current_inode
+    finally:
+        if not holder_released:
+            holder.release()
+        release_event.set()
+        waiter.join(timeout=30)
+        if waiter.is_alive():
+            waiter.terminate()
+            waiter.join(timeout=30)
+        inode_queue.close()
+        inode_queue.join_thread()
+
+    assert waiter.exitcode == 0
+```
+
+- [ ] **Step 2: Verify the regression detects portalocker 3.3.0 behavior**
+
+Temporarily replace only the body of
+`TemporaryFileLock._acquire_verified()` in `portalocker/utils.py` with the
+pre-fix behavior below. Do not stage or commit this temporary edit:
+
+```python
+        return Lock.acquire(
+            lock,
+            timeout,
+            check_interval,
+            fail_when_locked,
+        )
+```
+
+Run:
+
+```bash
+uv run pytest \
+  portalocker_tests/test_multiprocess.py::test_temporary_lock_waiters_converge_on_current_inode \
+  --no-cov -q
+```
+
+Expected: both parameter cases fail because the third acquisition succeeds,
+so `pytest.raises(portalocker.AlreadyLocked)` reports `DID NOT RAISE`.
+
+- [ ] **Step 3: Restore the existing inode-verification implementation**
+
+Restore the method body exactly:
+
+```python
+        for _ in lock._timeout_generator(timeout, check_interval):
+            fh = Lock.acquire(lock, timeout, check_interval, fail_when_locked)
+            if os.name == 'nt':  # Windows: a locked file can't be swapped.
+                return fh  # pragma: not-nt
+            if _fh_matches_path(fh, filename):  # pragma: not-posix
+                return fh  # pragma: not-posix
+            # Stale handle: the path was unlinked+recreated behind our back.
+            Lock.release(lock)  # pragma: not-posix
+        raise exceptions.AlreadyLocked(  # pragma: not-posix
+            exceptions.LockException.LOCK_FAILED,
+            f'{filename!r} kept being replaced while locking (split-brain)',
+        )
+```
+
+Confirm `git diff -- portalocker/utils.py` is empty.
+
+- [ ] **Step 4: Run the focused regression against the selected implementation**
+
+Run:
+
+```bash
+uv run pytest \
+  portalocker_tests/test_multiprocess.py::test_temporary_lock_waiters_converge_on_current_inode \
+  --no-cov -q
+```
+
+Expected: `2 passed`.
+
+- [ ] **Step 5: Check the changed test file**
+
+Run:
+
+```bash
+uv run ruff check portalocker_tests/test_multiprocess.py
+uv run ruff format --check portalocker_tests/test_multiprocess.py
+uv run mypy portalocker_tests/test_multiprocess.py
+```
+
+Expected: all commands exit 0 without diagnostics.
+
+- [ ] **Step 6: Commit the regression**
+
+```bash
+git add portalocker_tests/test_multiprocess.py
+git commit -m 'test #115 split-inode waiters across processes'
+```
+
+### Task 2: Correct issue attribution
+
+**Files:**
+
+- Modify: `CHANGELOG.rst`
+- Modify: `portalocker_tests/test_temporary_file_lock.py`
+- Modify: `portalocker_tests/test_pidfilelock.py`
+
+- [ ] **Step 1: Attribute #115 to the split-inode fix**
+
+Change the split-brain changelog bullet to end with:
+
+```rst
+after locking (#115)
+```
+
+Remove `(#115)` from the separate stale-object release bullet. Preserve the
+rest of both bullets unchanged.
+
+Change the two stale-release regression docstrings so they no longer claim to
+cover #115:
+
+```python
+def test_temporaryfilelock_release_without_ownership_keeps_file(tmpfile):
+    """Releasing a lock object that holds nothing must not unlink the path.
+
+    A stale object (double release or GC of a failed acquire) would otherwise
+    destroy the current holder's lock file.
+    """
+```
+
+```python
+def test_pidfilelock_release_without_ownership_keeps_files(tmp_path):
+    """A stale PidFileLock must not unlink a current holder's files.
+
+    This covers double release and garbage collection after a failed acquire.
+    """
+```
+
+- [ ] **Step 2: Verify the attribution-only changes**
+
+Run:
+
+```bash
+uv run pytest \
+  portalocker_tests/test_temporary_file_lock.py::test_temporaryfilelock_release_without_ownership_keeps_file \
+  portalocker_tests/test_pidfilelock.py::test_pidfilelock_release_without_ownership_keeps_files \
+  --no-cov -q
+uv run codespell \
+  CHANGELOG.rst \
+  portalocker_tests/test_temporary_file_lock.py \
+  portalocker_tests/test_pidfilelock.py
+git diff --check
+```
+
+Expected: `2 passed`; codespell and `git diff --check` exit 0.
+
+- [ ] **Step 3: Commit the attribution correction**
+
+```bash
+git add \
+  CHANGELOG.rst \
+  portalocker_tests/test_temporary_file_lock.py \
+  portalocker_tests/test_pidfilelock.py
+git commit -m 'correct #115 split-inode attribution'
+```
+
+### Task 3: Run complete verification
+
+**Files:**
+
+- Verify: all tracked changes on branch `issue-115`
+
+- [ ] **Step 1: Run the full test suite**
+
+Run:
+
+```bash
+uv run pytest
+```
+
+Expected on POSIX: `115 passed, 17 skipped`, 100% statement and branch
+coverage, exit 0.
+
+- [ ] **Step 2: Run all configured static checks**
+
+Run:
+
+```bash
+uv run ruff check
+uv run ruff format --check
+uv run mypy
+uv run basedpyright
+uv run pyrefly check
+uv run ty check
+uv run codespell
+```
+
+Expected: every command exits 0 without errors.
+
+- [ ] **Step 3: Verify branch scope and cleanliness**
+
+Run:
+
+```bash
+git diff --check afbf995...HEAD
+git diff --stat afbf995...HEAD
+git status --short --branch
+git log --oneline afbf995..HEAD
+```
+
+Expected: only the design, plan, issue regression, changelog attribution, and
+stale-test docstrings differ; the worktree is clean.

--- a/docs/superpowers/specs/2026-07-15-issue-115-inode-waiters-design.md
+++ b/docs/superpowers/specs/2026-07-15-issue-115-inode-waiters-design.md
@@ -1,0 +1,113 @@
+# Issue 115 Inode Waiters Design
+
+## Goal
+
+Prevent POSIX `TemporaryFileLock` and `PidFileLock` waiters from returning
+success while they hold an obsolete inode, without changing the observable
+behavior of portalocker 3.3.0.
+
+## Compatibility Contract
+
+Backwards compatibility with the current PyPI release takes priority over
+changing the lock-file lifecycle:
+
+- Public constructors, arguments, return values, timeout behavior, and
+  exceptions remain unchanged.
+- `TemporaryFileLock` continues to create its pathname while held and remove
+  it on ordinary release and finalization.
+- `PidFileLock` continues to remove both its PID file and sidecar lock file.
+- Windows behavior remains unchanged because Windows does not allow a locked
+  file to be unlinked.
+- `TemporaryFileLock` does not gain a persistent sidecar or leave a new
+  filesystem artifact.
+
+This preserves public behavior for applications upgrading from portalocker
+3.3.0. It does not promise safe simultaneous coordination between upgraded
+and legacy processes: portalocker 3.3.0 waiters do not perform inode
+revalidation, so new code cannot force them to reject an obsolete descriptor.
+
+## Root Cause
+
+On POSIX, a waiter can open a lock file before the current holder releases it.
+If release unlinks the pathname, the waiter retains a descriptor for the old
+inode. A third process can then recreate the pathname and lock a new inode. If
+the waiter returns after locking the old inode, both processes believe they
+hold the same named lock.
+
+The current branch already contains the intended compatibility-preserving
+defense: after acquiring a native lock, `_acquire_verified()` compares the
+descriptor inode with the inode currently named by the path. A missing or
+different path makes the acquisition stale; the code releases that descriptor
+and retries within the configured timeout.
+
+## Selected Design
+
+Keep inode revalidation as the coordination mechanism. An acquisition on
+POSIX succeeds only after all of these conditions hold:
+
+1. The process opens and natively locks a file descriptor.
+2. The lock pathname exists.
+3. `fstat()` on the descriptor and `stat()` on the pathname identify the same
+   inode.
+
+If either pathname check fails, release the stale native lock and retry using
+the existing timeout and polling contract. If the deadline expires or
+`fail_when_locked` requires an immediate failure, surface the existing
+`AlreadyLocked` behavior. Do not add a persistent lock file, new public API,
+or platform-specific cleanup contract.
+
+Apply the same invariant to the `PidFileLock` sidecar because it has the same
+open-wait-unlink race.
+
+## Implementation Scope
+
+The production implementation is already present on the current branch. Add
+the missing end-to-end regression before deciding whether production changes
+are necessary. Change production code only if that regression demonstrates a
+remaining violation of the selected invariant.
+
+Correct the changelog attribution at the same time:
+
+- Associate issue #115 with the split-inode waiter fix.
+- Keep the stale-object release fix documented, but do not attribute that
+  separate problem to #115.
+
+## Regression Test
+
+Add an event-driven, POSIX-only multiprocessing regression covering both
+`TemporaryFileLock` and `PidFileLock`:
+
+1. The parent acquires the named lock.
+2. A waiter process opens the current native lock inode and signals that the
+   descriptor is open before attempting acquisition.
+3. The parent releases its lock only after receiving that signal.
+4. The waiter returns from `acquire()` and keeps its lock held.
+5. A third acquisition against the same pathname must raise `AlreadyLocked`.
+6. For `TemporaryFileLock`, and for the `PidFileLock` sidecar, the waiter's
+   descriptor inode must match the inode currently named by the lock path.
+7. Events release the waiter and all child processes are joined and checked
+   for clean exit.
+
+Use process events and queues instead of timing sleeps. Run the regression on
+Linux and macOS; skip it on Windows where unlinking a locked file is not
+possible.
+
+The test must fail against the portalocker 3.3.0 release behavior by allowing
+the third acquisition, then pass against the implementation on this branch.
+
+## Verification
+
+- Run the new focused multiprocessing regression.
+- Run the complete pytest suite with its configured 100% coverage threshold.
+- Run the repository's configured static checks relevant to changed Python
+  and documentation files.
+- Confirm the worktree diff contains only issue #115 tests, any demonstrated
+  production correction, and the changelog attribution update.
+
+## Out of Scope
+
+- Changing `TemporaryFileLock` to retain its lock file after release.
+- Adding a permanent sidecar to `TemporaryFileLock`.
+- Guaranteeing coordination with concurrently running legacy portalocker
+  processes.
+- Refactoring unrelated locking behavior or dependency configuration.

--- a/portalocker_tests/test_multiprocess.py
+++ b/portalocker_tests/test_multiprocess.py
@@ -283,8 +283,8 @@ def test_temporary_lock_waiters_converge_on_current_inode(
     lock_kind: LockKind,
 ) -> None:
     """#115: waiters must reject an obsolete unlinked lock inode."""
-    context: multiprocessing.context.SpawnContext = multiprocessing.get_context(
-        'spawn'
+    context: multiprocessing.context.SpawnContext = (
+        multiprocessing.get_context('spawn')
     )
     filename: str = str(tmp_path / f'{lock_kind}.lock')
     native_filename: str = native_lock_path(filename, lock_kind)

--- a/portalocker_tests/test_multiprocess.py
+++ b/portalocker_tests/test_multiprocess.py
@@ -1,15 +1,25 @@
+from __future__ import annotations
+
 import dataclasses
 import importlib.util
 import multiprocessing
+import multiprocessing.context
+import multiprocessing.process
+import multiprocessing.queues
 import multiprocessing.synchronize
 import os
+import pathlib
 import platform
 import time
+import typing
+from unittest import mock
 
 import pytest
 
 import portalocker
-from portalocker import LockFlags
+from portalocker import LockFlags, utils
+
+LockKind: typing.TypeAlias = typing.Literal['temporary', 'pid']
 
 # On Windows without the optional pywin32 extra, shared locks are unsupported
 # by design and raise ImportError (in the *spawned* children). Skip in the
@@ -28,6 +38,74 @@ class LockResult:
     exception_class: type[BaseException] | None = None
     exception_message: str | None = None
     exception_repr: str | None = None
+
+
+def make_temporary_lock(
+    filename: str,
+    lock_kind: LockKind,
+    *,
+    timeout: float,
+    fail_when_locked: bool,
+) -> portalocker.TemporaryFileLock:
+    """Create one of the temporary-path lock implementations under test."""
+    lock_type: type[portalocker.TemporaryFileLock]
+    if lock_kind == 'temporary':
+        lock_type = portalocker.TemporaryFileLock
+    else:
+        lock_type = portalocker.PidFileLock
+    return lock_type(
+        filename,
+        timeout=timeout,
+        fail_when_locked=fail_when_locked,
+    )
+
+
+def native_lock_path(filename: str, lock_kind: LockKind) -> str:
+    """Return the pathname carrying the native OS lock."""
+    if lock_kind == 'pid':
+        return f'{filename}.lock'
+    return filename
+
+
+def hold_inode_waiter(
+    filename: str,
+    lock_kind: LockKind,
+    native_filename: str,
+    opened_event: multiprocessing.synchronize.Event,
+    acquired_event: multiprocessing.synchronize.Event,
+    release_event: multiprocessing.synchronize.Event,
+    inode_queue: multiprocessing.queues.Queue[int],
+) -> None:
+    """Open the original inode, acquire, report it, and hold the lock."""
+    original_get_fh: typing.Callable[
+        [utils.Lock],
+        typing.IO[typing.Any],
+    ] = typing.cast(
+        typing.Callable[[utils.Lock], typing.IO[typing.Any]],
+        utils.Lock._get_fh,
+    )
+
+    def announce_open(lock: utils.Lock) -> typing.IO[typing.Any]:
+        fh: typing.IO[typing.Any] = original_get_fh(lock)
+        if lock.filename == native_filename:
+            opened_event.set()
+        return fh
+
+    lock: portalocker.TemporaryFileLock = make_temporary_lock(
+        filename,
+        lock_kind,
+        timeout=30,
+        fail_when_locked=False,
+    )
+    try:
+        with mock.patch.object(utils.Lock, '_get_fh', announce_open):
+            fh: typing.IO[typing.Any] = lock.acquire()
+        inode_queue.put(os.fstat(fh.fileno()).st_ino)
+        acquired_event.set()
+        if not release_event.wait(timeout=30):
+            raise TimeoutError('parent did not release the inode waiter')
+    finally:
+        lock.release()
 
 
 def lock(
@@ -189,3 +267,85 @@ def test_exclusive_processes(
         holder.join(timeout=30)
 
     assert holder.exitcode == 0
+
+
+@pytest.mark.parametrize('lock_kind', ['temporary', 'pid'])
+@pytest.mark.skipif(
+    os.name == 'nt',
+    reason='POSIX-only inode replacement race',
+)
+@pytest.mark.skipif(
+    'pypy' in platform.python_implementation().lower(),
+    reason='pypy3 does not support the multiprocessing test',
+)
+def test_temporary_lock_waiters_converge_on_current_inode(
+    tmp_path: pathlib.Path,
+    lock_kind: LockKind,
+) -> None:
+    """#115: waiters must reject an obsolete unlinked lock inode."""
+    context: multiprocessing.context.SpawnContext = multiprocessing.get_context(
+        'spawn'
+    )
+    filename: str = str(tmp_path / f'{lock_kind}.lock')
+    native_filename: str = native_lock_path(filename, lock_kind)
+    holder: portalocker.TemporaryFileLock = make_temporary_lock(
+        filename,
+        lock_kind,
+        timeout=30,
+        fail_when_locked=False,
+    )
+    opened_event: multiprocessing.synchronize.Event = context.Event()
+    acquired_event: multiprocessing.synchronize.Event = context.Event()
+    release_event: multiprocessing.synchronize.Event = context.Event()
+    inode_queue: multiprocessing.queues.Queue[int] = context.Queue()
+    waiter: multiprocessing.process.BaseProcess = context.Process(
+        target=hold_inode_waiter,
+        args=(
+            filename,
+            lock_kind,
+            native_filename,
+            opened_event,
+            acquired_event,
+            release_event,
+            inode_queue,
+        ),
+    )
+    holder_released: bool = False
+
+    holder.acquire()
+    waiter.start()
+    try:
+        assert opened_event.wait(timeout=30), (
+            'waiter never opened the holder inode'
+        )
+        holder.release()
+        holder_released = True
+        assert acquired_event.wait(timeout=30), 'waiter never acquired'
+
+        waiter_inode: int = inode_queue.get(timeout=30)
+        contender: portalocker.TemporaryFileLock = make_temporary_lock(
+            filename,
+            lock_kind,
+            timeout=0,
+            fail_when_locked=True,
+        )
+        try:
+            with pytest.raises(portalocker.AlreadyLocked):
+                contender.acquire()
+        finally:
+            contender.release()
+
+        current_inode: int = os.stat(native_filename).st_ino
+        assert waiter_inode == current_inode
+    finally:
+        if not holder_released:
+            holder.release()
+        release_event.set()
+        waiter.join(timeout=30)
+        if waiter.is_alive():
+            waiter.terminate()
+            waiter.join(timeout=30)
+        inode_queue.close()
+        inode_queue.join_thread()
+
+    assert waiter.exitcode == 0

--- a/portalocker_tests/test_pidfilelock.py
+++ b/portalocker_tests/test_pidfilelock.py
@@ -445,8 +445,10 @@ def test_pidfilelock_releases_sidecar_on_pid_write_failure(
 
 
 def test_pidfilelock_release_without_ownership_keeps_files(tmp_path):
-    """#115: a stale PidFileLock (double release or GC'd failed acquire)
-    must not unlink the PID file or sidecar out from under the holder."""
+    """A stale PidFileLock must not unlink a current holder's files.
+
+    This covers double release and garbage collection after a failed acquire.
+    """
     pid_file = str(tmp_path / 'stale.pid')
 
     stale = utils.PidFileLock(pid_file)

--- a/portalocker_tests/test_temporary_file_lock.py
+++ b/portalocker_tests/test_temporary_file_lock.py
@@ -164,9 +164,11 @@ def test_temporaryfilelock_sequential_cycles(tmpfile):
 
 
 def test_temporaryfilelock_release_without_ownership_keeps_file(tmpfile):
-    """#115: releasing a lock object that holds nothing must not unlink the
-    path - a stale object (double release or GC of a failed acquire) would
-    otherwise destroy the current holder's lock file."""
+    """Releasing a lock object that holds nothing must not unlink the path.
+
+    A stale object (double release or GC of a failed acquire) would otherwise
+    destroy the current holder's lock file.
+    """
     stale = portalocker.TemporaryFileLock(tmpfile)
     stale.acquire()
     stale.release()


### PR DESCRIPTION
## Summary

- add a deterministic POSIX multiprocessing regression for `TemporaryFileLock` and `PidFileLock`
- verify waiters reject obsolete unlinked inodes while preserving portalocker 3.3.0 cleanup behavior
- attribute #115 to the split-inode fix instead of the unrelated stale-release fix

## Root cause

A waiter can open the current lock file before its holder releases and unlinks it. Without post-acquisition inode validation, that waiter can lock the obsolete inode while another process recreates and locks the same pathname on a new inode.

The current feature branch already performs inode revalidation. This PR adds the missing end-to-end proof and changes no production or public API behavior.

## Impact

`TemporaryFileLock` and `PidFileLock` retain their current delete-on-release behavior. No persistent sidecar or new filesystem artifact is introduced for `TemporaryFileLock`.

## Validation

- disabled inode validation: both regression cases failed because a third acquisition succeeded
- restored inode validation: 2 focused regression cases passed
- full pytest suite: 115 passed, 17 skipped, 100% coverage
- mypy: no issues in 27 source files
- basedpyright: 0 errors
- pyrefly: 0 errors
- ty: all checks passed
- codespell: passed

Closes #115