### PR TITLE
Fix open_atomic no-replace publication

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,5 +1,8 @@
 4.0.0:
 
+ * Fixed ``open_atomic()`` replacing a destination created while its context
+   was open on POSIX; publication now raises ``FileExistsError`` and preserves
+   the concurrent winner (#114)
  * Python 3.10 or later is now required; Python 3.9 (EOL) support dropped
  * ``pywin32`` is no longer installed by default on Windows; the msvcrt-based
    locker is the default and works dependency-free for exclusive locks.
@@ -122,4 +125,3 @@ https://github.com/WoLpH/portalocker/commits/master
 0.1:
 
  * Initial release
-

--- a/docs/superpowers/plans/2026-07-16-open-atomic-no-replace.md
+++ b/docs/superpowers/plans/2026-07-16-open-atomic-no-replace.md
@@ -9,11 +9,11 @@ checkbox (`- [ ]`) syntax for tracking.
 destination created before publication, while preserving its existing API and
 entry-time `AssertionError` behavior.
 
-**Architecture:** Keep the existing same-directory temporary-file workflow and
-replace the final `os.rename()` with atomic hard-link publication through
-`os.link()`. Turn the removable entry assertion into an explicit
-`AssertionError`, retain unconditional temporary-file cleanup, and document the
-no-replacement contract.
+**Architecture:** Keep the existing same-directory temporary-file workflow,
+retain atomic `os.rename()` publication on Windows, and use atomic hard-link
+publication through `os.link()` on POSIX. Turn the removable entry assertion
+into an explicit `AssertionError`, retain unconditional temporary-file cleanup,
+and document the no-replacement contract.
 
 **Tech Stack:** Python 3.10+, `contextlib`, `os`, `pathlib`, `tempfile`, pytest,
 uv, mypy, basedpyright, pyrefly, ty, Sphinx.
@@ -68,13 +68,16 @@ uv run pytest --no-cov portalocker_tests/test_open_atomic.py::test_open_atomic_p
 Expected: FAIL with `Failed: DID NOT RAISE <class 'FileExistsError'>`; the
 current POSIX `os.rename()` replaces the concurrent winner.
 
-- [ ] **Step 3: Publish with an atomic no-replace hard link**
+- [ ] **Step 3: Publish with the platform's atomic no-replace primitive**
 
 In `portalocker/utils.py`, replace the publication call only:
 
 ```python
     try:
-        os.link(temp_fh.name, path)
+        if os.name == 'nt':  # pragma: not-nt
+            os.rename(temp_fh.name, path)
+        else:  # pragma: not-posix
+            os.link(temp_fh.name, path)
     finally:
         with contextlib.suppress(Exception):
             os.remove(temp_fh.name)
@@ -236,21 +239,22 @@ def test_open_atomic_publishes_without_leaving_temporary_file(
     assert set(tmp_path.iterdir()) == entries_before | {target}
 
 
-def test_open_atomic_cleans_temporary_file_after_link_error(
+def test_open_atomic_cleans_temporary_file_after_publication_error(
     tmp_path: pathlib.Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     target: pathlib.Path = tmp_path / 'destination.bin'
     temporary_paths: list[pathlib.Path] = []
 
-    def fail_link(source: str, destination: pathlib.Path) -> None:
+    def fail_publication(source: str, destination: pathlib.Path) -> None:
         temporary_paths.append(pathlib.Path(source))
         assert destination == target
-        raise OSError('link publication failed')
+        raise OSError('publication failed')
 
-    monkeypatch.setattr(os, 'link', fail_link)
+    publication_function: str = 'rename' if os.name == 'nt' else 'link'
+    monkeypatch.setattr(os, publication_function, fail_publication)
 
-    with pytest.raises(OSError, match='link publication failed'):
+    with pytest.raises(OSError, match='publication failed'):
         with portalocker.open_atomic(target) as temporary:
             written: int = temporary.write(b'unpublished payload')
             assert written == len(b'unpublished payload')
@@ -298,8 +302,9 @@ Replace the opening paragraphs of `open_atomic()` with:
     :class:`FileExistsError` and leaves that destination untouched.
 
     The implementation writes and synchronizes a temporary file in the
-    destination directory, then publishes it with an atomic hard link. The
-    filesystem must support hard links.
+    destination directory, then publishes it with an operation that refuses an
+    existing destination. Windows uses an atomic rename; POSIX uses an atomic
+    hard link, so the POSIX filesystem must support hard links.
 
     https://docs.python.org/3/library/os.html#os.link
 ```

--- a/docs/superpowers/plans/2026-07-16-open-atomic-no-replace.md
+++ b/docs/superpowers/plans/2026-07-16-open-atomic-no-replace.md
@@ -1,0 +1,389 @@
+# `open_atomic()` No-Replace Implementation Plan
+
+**For agentic workers:** REQUIRED SUB-SKILL: Use
+superpowers:subagent-driven-development (recommended) or
+superpowers:executing-plans to implement this plan task-by-task. Steps use
+checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `open_atomic()` publish atomically without replacing a
+destination created before publication, while preserving its existing API and
+entry-time `AssertionError` behavior.
+
+**Architecture:** Keep the existing same-directory temporary-file workflow and
+replace the final `os.rename()` with atomic hard-link publication through
+`os.link()`. Turn the removable entry assertion into an explicit
+`AssertionError`, retain unconditional temporary-file cleanup, and document the
+no-replacement contract.
+
+**Tech Stack:** Python 3.10+, `contextlib`, `os`, `pathlib`, `tempfile`, pytest,
+uv, mypy, basedpyright, pyrefly, ty, Sphinx.
+
+---
+
+### Task 1: Prevent Replacement During Publication
+
+**Files:**
+
+- Create: `portalocker_tests/test_open_atomic.py`
+- Modify: `portalocker/utils.py:108-112`
+
+- [ ] **Step 1: Write the failing publication-race test**
+
+Create `portalocker_tests/test_open_atomic.py` with:
+
+```python
+from __future__ import annotations
+
+import pathlib
+
+import pytest
+
+import portalocker
+
+
+def test_open_atomic_preserves_destination_created_before_publication(
+    tmp_path: pathlib.Path,
+) -> None:
+    target: pathlib.Path = tmp_path / 'destination.bin'
+    entries_before: set[pathlib.Path] = set(tmp_path.iterdir())
+
+    with pytest.raises(FileExistsError):
+        with portalocker.open_atomic(target) as temporary:
+            written: int = temporary.write(b'temporary payload')
+            assert written == len(b'temporary payload')
+            target.write_bytes(b'concurrent winner')
+
+    assert target.read_bytes() == b'concurrent winner'
+    assert set(tmp_path.iterdir()) == entries_before | {target}
+```
+
+- [ ] **Step 2: Run the test and verify the race reproduces**
+
+Run:
+
+```bash
+uv run pytest --no-cov portalocker_tests/test_open_atomic.py::test_open_atomic_preserves_destination_created_before_publication -v
+```
+
+Expected: FAIL with `Failed: DID NOT RAISE <class 'FileExistsError'>`; the
+current POSIX `os.rename()` replaces the concurrent winner.
+
+- [ ] **Step 3: Publish with an atomic no-replace hard link**
+
+In `portalocker/utils.py`, replace the publication call only:
+
+```python
+    try:
+        os.link(temp_fh.name, path)
+    finally:
+        with contextlib.suppress(Exception):
+            os.remove(temp_fh.name)
+```
+
+- [ ] **Step 4: Run the focused test and verify it passes**
+
+Run:
+
+```bash
+uv run pytest --no-cov portalocker_tests/test_open_atomic.py::test_open_atomic_preserves_destination_created_before_publication -v
+```
+
+Expected: PASS. The destination contains `b'concurrent winner'`, and only the
+destination remains in the directory.
+
+- [ ] **Step 5: Commit the red/green change**
+
+```bash
+git add portalocker/utils.py portalocker_tests/test_open_atomic.py
+git commit -m "fix: prevent open_atomic replacing concurrent destination"
+```
+
+### Task 2: Preserve the Entry Check Under Optimized Python
+
+**Files:**
+
+- Modify: `portalocker_tests/test_open_atomic.py`
+- Modify: `portalocker/utils.py:94`
+
+- [ ] **Step 1: Add a failing optimized-mode compatibility test**
+
+Add these imports to `portalocker_tests/test_open_atomic.py`:
+
+```python
+import subprocess
+import sys
+import textwrap
+```
+
+Then add:
+
+```python
+def test_open_atomic_existing_destination_check_survives_optimization(
+    tmp_path: pathlib.Path,
+) -> None:
+    target: pathlib.Path = tmp_path / 'destination.bin'
+    existing: bytes = b'existing destination'
+    expected_message: str = f'{target!r} exists'
+    target.write_bytes(existing)
+
+    with pytest.raises(AssertionError, match='exists'):
+        with portalocker.open_atomic(target):
+            pass
+
+    script: str = textwrap.dedent(
+        f'''\
+        import pathlib
+
+        import portalocker
+
+        target: pathlib.Path = pathlib.Path({str(target)!r})
+        expected: bytes = {existing!r}
+        expected_message: str = {expected_message!r}
+        try:
+            with portalocker.open_atomic(target):
+                pass
+        except AssertionError as error:
+            if str(error) != expected_message:
+                raise
+        else:
+            raise RuntimeError('missing AssertionError under optimized Python')
+        if target.read_bytes() != expected:
+            raise RuntimeError('existing destination was modified')
+        ''',
+    )
+    completed: subprocess.CompletedProcess[str] = subprocess.run(
+        [sys.executable, '-O', '-c', script],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    assert completed.stdout == ''
+    assert completed.stderr == ''
+    assert target.read_bytes() == existing
+```
+
+- [ ] **Step 2: Run the optimized-mode test and verify it fails**
+
+Run:
+
+```bash
+uv run pytest --no-cov portalocker_tests/test_open_atomic.py::test_open_atomic_existing_destination_check_survives_optimization -v
+```
+
+Expected: FAIL with `subprocess.CalledProcessError`; `python -O` removes the
+current assertion, so the child process reaches publication instead of raising
+the compatibility exception.
+
+- [ ] **Step 3: Replace the removable assertion with an explicit exception**
+
+In `portalocker/utils.py`, replace the assertion with:
+
+```python
+    if path.exists():
+        raise AssertionError(f'{path!r} exists')
+```
+
+- [ ] **Step 4: Run the optimized-mode test and verify it passes**
+
+Run:
+
+```bash
+uv run pytest --no-cov portalocker_tests/test_open_atomic.py::test_open_atomic_existing_destination_check_survives_optimization -v
+```
+
+Expected: PASS in both the pytest process and its optimized child process.
+
+- [ ] **Step 5: Run both regression tests**
+
+Run:
+
+```bash
+uv run pytest --no-cov portalocker_tests/test_open_atomic.py -v
+```
+
+Expected: 2 passed.
+
+- [ ] **Step 6: Commit the compatibility fix**
+
+```bash
+git add portalocker/utils.py portalocker_tests/test_open_atomic.py
+git commit -m "fix: preserve open_atomic check under optimization"
+```
+
+### Task 3: Cover Success and Non-Collision Failure Cleanup
+
+**Files:**
+
+- Modify: `portalocker_tests/test_open_atomic.py`
+
+- [ ] **Step 1: Add success and publication-error characterization tests**
+
+Add `import os` to `portalocker_tests/test_open_atomic.py`, then add:
+
+```python
+def test_open_atomic_publishes_without_leaving_temporary_file(
+    tmp_path: pathlib.Path,
+) -> None:
+    target: pathlib.Path = tmp_path / 'destination.bin'
+    entries_before: set[pathlib.Path] = set(tmp_path.iterdir())
+
+    with portalocker.open_atomic(target) as temporary:
+        written: int = temporary.write(b'published payload')
+        assert written == len(b'published payload')
+
+    assert target.read_bytes() == b'published payload'
+    assert set(tmp_path.iterdir()) == entries_before | {target}
+
+
+def test_open_atomic_cleans_temporary_file_after_link_error(
+    tmp_path: pathlib.Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    target: pathlib.Path = tmp_path / 'destination.bin'
+    temporary_paths: list[pathlib.Path] = []
+
+    def fail_link(source: str, destination: pathlib.Path) -> None:
+        temporary_paths.append(pathlib.Path(source))
+        assert destination == target
+        raise OSError('link publication failed')
+
+    monkeypatch.setattr(os, 'link', fail_link)
+
+    with pytest.raises(OSError, match='link publication failed'):
+        with portalocker.open_atomic(target) as temporary:
+            written: int = temporary.write(b'unpublished payload')
+            assert written == len(b'unpublished payload')
+
+    assert len(temporary_paths) == 1
+    assert not temporary_paths[0].exists()
+    assert not target.exists()
+    assert not any(tmp_path.iterdir())
+```
+
+- [ ] **Step 2: Run all focused tests**
+
+Run:
+
+```bash
+uv run pytest --no-cov portalocker_tests/test_open_atomic.py -v
+```
+
+Expected: 4 passed. These tests characterize the retained success and cleanup
+behavior around the new publication primitive.
+
+- [ ] **Step 3: Commit the cleanup coverage**
+
+```bash
+git add portalocker_tests/test_open_atomic.py
+git commit -m "test: cover open_atomic publication cleanup"
+```
+
+### Task 4: Document the No-Replace Contract
+
+**Files:**
+
+- Modify: `portalocker/utils.py:63-86`
+- Modify: `CHANGELOG.rst:1-25`
+
+- [ ] **Step 1: Update the function docstring**
+
+Replace the opening paragraphs of `open_atomic()` with:
+
+```python
+    """Open a new file for atomic writing without replacing an existing file.
+
+    The destination must not exist when entering or publishing the context. If
+    another actor creates it while the context is open, publication raises
+    :class:`FileExistsError` and leaves that destination untouched.
+
+    The implementation writes and synchronizes a temporary file in the
+    destination directory, then publishes it with an atomic hard link. The
+    filesystem must support hard links.
+
+    https://docs.python.org/3/library/os.html#os.link
+```
+
+Keep the existing doctest examples below these paragraphs.
+
+- [ ] **Step 2: Add the changelog entry**
+
+Add this bullet to the 4.0.0 section in `CHANGELOG.rst`:
+
+```rst
+* Fixed ``open_atomic()`` replacing a destination created while its context was
+  open on POSIX; publication now raises ``FileExistsError`` and preserves the
+  concurrent winner (#114)
+```
+
+- [ ] **Step 3: Run the focused tests and doctests**
+
+Run:
+
+```bash
+uv run pytest --no-cov portalocker_tests/test_open_atomic.py portalocker/utils.py -v
+```
+
+Expected: all focused tests and `portalocker.utils` doctests pass. The full-suite
+coverage gate remains in Task 5.
+
+- [ ] **Step 4: Commit the documentation**
+
+```bash
+git add portalocker/utils.py CHANGELOG.rst
+git commit -m "docs: define open_atomic no-replace contract"
+```
+
+### Task 5: Full Verification
+
+**Files:**
+
+- Verify only; no planned modifications.
+
+- [ ] **Step 1: Run the complete test suite with coverage**
+
+```bash
+uv run pytest
+```
+
+Expected: exit 0, no failures, and 100% coverage.
+
+- [ ] **Step 2: Run all configured static type checkers**
+
+```bash
+uv run mypy
+uv run basedpyright
+uv run pyrefly check
+uv run ty check
+```
+
+Expected: each command exits 0 with no errors.
+
+- [ ] **Step 3: Run spelling and documentation checks**
+
+```bash
+uv run codespell
+mkdir -p docs/_static
+uv run sphinx-build -W -b html docs docs/_build/html
+```
+
+Expected: each command exits 0 with no spelling errors or Sphinx warnings.
+
+- [ ] **Step 4: Build both distributions**
+
+```bash
+uv build
+```
+
+Expected: exit 0 with a source distribution and wheel in `dist/`.
+
+- [ ] **Step 5: Inspect the final repository state**
+
+```bash
+git diff --check HEAD~4..HEAD
+git status --short --branch
+git log --oneline --decorate -6
+```
+
+Expected: no whitespace errors; the worktree is clean on `issue-114`; the
+design, plan, implementation, tests, and documentation commits are present.

--- a/docs/superpowers/specs/2026-07-15-open-atomic-no-replace-design.md
+++ b/docs/superpowers/specs/2026-07-15-open-atomic-no-replace-design.md
@@ -1,0 +1,92 @@
+# `open_atomic()` No-Replace Publication Design
+
+## Context
+
+`open_atomic()` writes to a temporary file in the destination directory,
+flushes and synchronizes that file, then publishes it with `os.rename()`.
+The function checks at entry that the destination is absent, but that check is
+an `assert`. Optimized Python removes it. More importantly, a destination
+created after context entry is silently replaced by `os.rename()` on POSIX,
+while Windows normally rejects the same race. Issue #114 reports this
+platform-dependent data-loss window.
+
+## Compatibility Contract
+
+The function remains a create-if-absent API. Its public signature, yielded file
+object, binary and text modes, parent-directory creation, flush, `fsync()`, and
+successful publication behavior remain unchanged.
+
+For compatibility with existing callers, a destination that already exists at
+context entry continues to raise `AssertionError` with the existing message.
+The check becomes explicit so it remains active under `python -O`.
+
+If another actor creates the destination after context entry, that actor wins.
+Publication raises `FileExistsError`, leaves the destination untouched, and
+removes the unpublished temporary file. This matches existing Windows race
+behavior and replaces unsafe POSIX replacement behavior.
+
+If the filesystem cannot provide the required atomic no-replace primitive,
+`open_atomic()` propagates the relevant `OSError`. It must never fall back to a
+replacement operation because that would violate the contract and reintroduce
+the data-loss race.
+
+## Publication Design
+
+The existing temporary file remains in the destination directory, ensuring the
+temporary file and destination are on the same filesystem. After the context
+body completes, `open_atomic()` flushes and synchronizes the temporary file as
+it does today.
+
+Publication uses `os.link(temporary_name, destination)`. Creating a hard link
+is atomic and refuses an existing destination. The temporary filename is then
+removed, leaving the destination as the sole name for the synchronized inode.
+The existing `finally` cleanup remains responsible for removing the temporary
+filename on success and failure.
+
+The entry check becomes an explicit conditional that raises `AssertionError`.
+No new option or replacement mode is added.
+
+## Error Handling
+
+- Existing destination at entry: raise the existing `AssertionError` before
+  creating a temporary file.
+- Destination created during the context: propagate `FileExistsError` from
+  `os.link()` and preserve the concurrent destination.
+- Other link failures: propagate the original `OSError` without attempting a
+  weaker publication method.
+- Context-body, flush, or `fsync()` failure: retain current behavior and do not
+  publish the destination.
+- All publication outcomes: best-effort removal of the temporary filename,
+  matching current cleanup behavior.
+
+## Testing
+
+Add focused tests for these externally visible behaviors:
+
+1. A destination present at entry raises `AssertionError`, including under
+   optimized Python, and its contents remain unchanged.
+2. A destination created inside the context causes publication to raise
+   `FileExistsError`.
+3. The concurrent winner's contents remain unchanged after the failed
+   publication.
+4. The temporary file is removed after failed publication.
+5. A normal publication still produces the written bytes and leaves no
+   temporary file behind.
+6. A non-`FileExistsError` publication failure propagates and still removes the
+   temporary file.
+
+Run the complete test suite and the repository's configured type and lint
+checks after the focused tests pass.
+
+## Documentation
+
+Update the `open_atomic()` docstring to state that the destination must not
+exist at entry or publication time. Add a changelog item describing the race
+fix and its `FileExistsError` outcome.
+
+## Non-Goals
+
+- Adding an atomic-replacement mode.
+- Adding platform-specific native rename bindings.
+- Changing locking APIs or other temporary-file utilities.
+- Guaranteeing operation on filesystems without hard-link support.

--- a/docs/superpowers/specs/2026-07-15-open-atomic-no-replace-design.md
+++ b/docs/superpowers/specs/2026-07-15-open-atomic-no-replace-design.md
@@ -25,10 +25,11 @@ Publication raises `FileExistsError`, leaves the destination untouched, and
 removes the unpublished temporary file. This matches existing Windows race
 behavior and replaces unsafe POSIX replacement behavior.
 
-If the filesystem cannot provide the required atomic no-replace primitive,
-`open_atomic()` propagates the relevant `OSError`. It must never fall back to a
-replacement operation because that would violate the contract and reintroduce
-the data-loss race.
+If a POSIX filesystem cannot create hard links, `open_atomic()` propagates the
+relevant `OSError`. It must never fall back to a replacement operation because
+that would violate the contract and reintroduce the data-loss race. Windows
+retains its existing atomic `os.rename()` publication, which already refuses an
+existing destination and supports filesystems without hard links.
 
 ## Publication Design
 
@@ -37,11 +38,13 @@ temporary file and destination are on the same filesystem. After the context
 body completes, `open_atomic()` flushes and synchronizes the temporary file as
 it does today.
 
-Publication uses `os.link(temporary_name, destination)`. Creating a hard link
-is atomic and refuses an existing destination. The temporary filename is then
-removed, leaving the destination as the sole name for the synchronized inode.
-The existing `finally` cleanup remains responsible for removing the temporary
-filename on success and failure.
+Publication uses `os.rename(temporary_name, destination)` on Windows because
+Windows rename is atomic and refuses an existing destination. POSIX publication
+uses `os.link(temporary_name, destination)`, which atomically refuses an
+existing destination; the temporary filename is then removed, leaving the
+destination as the sole name for the synchronized inode. The existing
+`finally` cleanup remains responsible for removing the temporary filename on
+success and failure.
 
 The entry check becomes an explicit conditional that raises `AssertionError`.
 No new option or replacement mode is added.
@@ -50,10 +53,10 @@ No new option or replacement mode is added.
 
 - Existing destination at entry: raise the existing `AssertionError` before
   creating a temporary file.
-- Destination created during the context: propagate `FileExistsError` from
-  `os.link()` and preserve the concurrent destination.
-- Other link failures: propagate the original `OSError` without attempting a
-  weaker publication method.
+- Destination created during the context: propagate `FileExistsError` from the
+  platform publication primitive and preserve the concurrent destination.
+- Other publication failures: propagate the original `OSError` without
+  attempting a weaker publication method.
 - Context-body, flush, or `fsync()` failure: retain current behavior and do not
   publish the destination.
 - All publication outcomes: best-effort removal of the temporary filename,
@@ -74,6 +77,7 @@ Add focused tests for these externally visible behaviors:
    temporary file behind.
 6. A non-`FileExistsError` publication failure propagates and still removes the
    temporary file.
+7. Windows selects `os.rename()` while POSIX selects `os.link()`.
 
 Run the complete test suite and the repository's configured type and lint
 checks after the focused tests pass.
@@ -89,4 +93,4 @@ fix and its `FileExistsError` outcome.
 - Adding an atomic-replacement mode.
 - Adding platform-specific native rename bindings.
 - Changing locking APIs or other temporary-file utilities.
-- Guaranteeing operation on filesystems without hard-link support.
+- Guaranteeing POSIX operation on filesystems without hard-link support.

--- a/portalocker/utils.py
+++ b/portalocker/utils.py
@@ -60,12 +60,17 @@ def open_atomic(
     filename: Filename,
     binary: bool = True,
 ) -> collections.abc.Generator[types.IO]:
-    """Open a file for atomic writing. Instead of locking this method allows
-    you to write the entire file and move it to the actual location. Note that
-    this makes the assumption that a rename is atomic on your platform which
-    is generally the case but not a guarantee.
+    """Open a new file for atomic writing without replacing an existing file.
 
-    http://docs.python.org/library/os.html#os.rename
+    The destination must not exist when entering or publishing the context. If
+    another actor creates it while the context is open, publication raises
+    :class:`FileExistsError` and leaves that destination untouched.
+
+    The implementation writes and synchronizes a temporary file in the
+    destination directory, then publishes it with an atomic hard link. The
+    filesystem must support hard links.
+
+    https://docs.python.org/3/library/os.html#os.link
 
     >>> filename = 'test_file.txt'
     >>> if os.path.exists(filename):

--- a/portalocker/utils.py
+++ b/portalocker/utils.py
@@ -91,7 +91,8 @@ def open_atomic(
     else:
         path = pathlib.Path(filename)
 
-    assert not path.exists(), f'{path!r} exists'
+    if path.exists():
+        raise AssertionError(f'{path!r} exists')
 
     # Create the parent directory if it doesn't exist
     path.parent.mkdir(parents=True, exist_ok=True)

--- a/portalocker/utils.py
+++ b/portalocker/utils.py
@@ -106,7 +106,7 @@ def open_atomic(
         os.fsync(temp_fh.fileno())
 
     try:
-        os.rename(temp_fh.name, path)
+        os.link(temp_fh.name, path)
     finally:
         with contextlib.suppress(Exception):
             os.remove(temp_fh.name)

--- a/portalocker/utils.py
+++ b/portalocker/utils.py
@@ -67,8 +67,9 @@ def open_atomic(
     :class:`FileExistsError` and leaves that destination untouched.
 
     The implementation writes and synchronizes a temporary file in the
-    destination directory, then publishes it with an atomic hard link. The
-    filesystem must support hard links.
+    destination directory, then publishes it with an operation that refuses an
+    existing destination. Windows uses an atomic rename; POSIX uses an atomic
+    hard link, so the POSIX filesystem must support hard links.
 
     https://docs.python.org/3/library/os.html#os.link
 
@@ -112,7 +113,10 @@ def open_atomic(
         os.fsync(temp_fh.fileno())
 
     try:
-        os.link(temp_fh.name, path)
+        if os.name == 'nt':  # pragma: not-nt
+            os.rename(temp_fh.name, path)
+        else:  # pragma: not-posix
+            os.link(temp_fh.name, path)
     finally:
         with contextlib.suppress(Exception):
             os.remove(temp_fh.name)

--- a/portalocker_tests/test_open_atomic.py
+++ b/portalocker_tests/test_open_atomic.py
@@ -27,37 +27,40 @@ def test_open_atomic_publishes_without_leaving_temporary_file(
     assert set(tmp_path.iterdir()) == entries_before | {target}
 
 
-def test_open_atomic_uses_rename_on_windows(
+def test_open_atomic_uses_platform_publication_primitive(
     tmp_path: pathlib.Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     target: pathlib.Path = tmp_path / 'destination.bin'
-    rename_calls: list[tuple[pathlib.Path, pathlib.Path]] = []
+    publication_calls: list[tuple[pathlib.Path, pathlib.Path]] = []
     real_replace: typing.Callable[[str, pathlib.Path], None] = typing.cast(
         typing.Callable[[str, pathlib.Path], None],
         os.replace,
     )
 
-    def fake_rename(source: str, destination: pathlib.Path) -> None:
-        rename_calls.append((pathlib.Path(source), destination))
+    def fake_publication(source: str, destination: pathlib.Path) -> None:
+        publication_calls.append((pathlib.Path(source), destination))
         real_replace(source, destination)
 
-    def fail_link(source: str, destination: pathlib.Path) -> None:
-        raise AssertionError(f'unexpected os.link({source!r}, {destination!r})')
+    def fail_unused_publication(source: str, destination: pathlib.Path) -> None:
+        raise AssertionError(
+            f'unexpected publication call: {source!r} -> {destination!r}'
+        )
 
-    monkeypatch.setattr(os, 'name', 'nt')
-    monkeypatch.setattr(os, 'rename', fake_rename)
-    monkeypatch.setattr(os, 'link', fail_link)
+    publication_function: str = 'rename' if os.name == 'nt' else 'link'
+    unused_publication_function: str = 'link' if os.name == 'nt' else 'rename'
+    monkeypatch.setattr(os, publication_function, fake_publication)
+    monkeypatch.setattr(os, unused_publication_function, fail_unused_publication)
 
     with portalocker.open_atomic(target) as file_handle:
         temporary: typing.BinaryIO = typing.cast(typing.BinaryIO, file_handle)
-        written: int = temporary.write(b'published with rename')
-        assert written == len(b'published with rename')
+        written: int = temporary.write(b'published payload')
+        assert written == len(b'published payload')
 
-    assert target.read_bytes() == b'published with rename'
-    assert len(rename_calls) == 1
-    assert rename_calls[0][1] == target
-    assert not rename_calls[0][0].exists()
+    assert target.read_bytes() == b'published payload'
+    assert len(publication_calls) == 1
+    assert publication_calls[0][1] == target
+    assert not publication_calls[0][0].exists()
 
 
 def test_open_atomic_cleans_temporary_file_after_publication_error(
@@ -75,14 +78,16 @@ def test_open_atomic_cleans_temporary_file_after_publication_error(
     publication_function: str = 'rename' if os.name == 'nt' else 'link'
     monkeypatch.setattr(os, publication_function, fail_publication)
 
-    with pytest.raises(OSError, match='publication failed'):
-        with portalocker.open_atomic(target) as file_handle:
-            temporary: typing.BinaryIO = typing.cast(
-                typing.BinaryIO,
-                file_handle,
-            )
-            written: int = temporary.write(b'unpublished payload')
-            assert written == len(b'unpublished payload')
+    with (
+        pytest.raises(OSError, match='publication failed'),
+        portalocker.open_atomic(target) as file_handle,
+    ):
+        temporary: typing.BinaryIO = typing.cast(
+            typing.BinaryIO,
+            file_handle,
+        )
+        written: int = temporary.write(b'unpublished payload')
+        assert written == len(b'unpublished payload')
 
     assert len(temporary_paths) == 1
     assert not temporary_paths[0].exists()
@@ -98,9 +103,11 @@ def test_open_atomic_existing_destination_check_survives_optimization(
     expected_message: str = f'{target!r} exists'
     target.write_bytes(existing)
 
-    with pytest.raises(AssertionError, match='exists'):
-        with portalocker.open_atomic(target):
-            pass
+    with (
+        pytest.raises(AssertionError, match='exists'),
+        portalocker.open_atomic(target),
+    ):
+        pass
 
     script: str = textwrap.dedent(
         f'''\
@@ -141,15 +148,17 @@ def test_open_atomic_preserves_destination_created_before_publication(
     target: pathlib.Path = tmp_path / 'destination.bin'
     entries_before: set[pathlib.Path] = set(tmp_path.iterdir())
 
-    with pytest.raises(FileExistsError):
-        with portalocker.open_atomic(target) as file_handle:
-            temporary: typing.BinaryIO = typing.cast(
-                typing.BinaryIO,
-                file_handle,
-            )
-            written: int = temporary.write(b'temporary payload')
-            assert written == len(b'temporary payload')
-            target.write_bytes(b'concurrent winner')
+    with (
+        pytest.raises(FileExistsError),
+        portalocker.open_atomic(target) as file_handle,
+    ):
+        temporary: typing.BinaryIO = typing.cast(
+            typing.BinaryIO,
+            file_handle,
+        )
+        written: int = temporary.write(b'temporary payload')
+        assert written == len(b'temporary payload')
+        target.write_bytes(b'concurrent winner')
 
     assert target.read_bytes() == b'concurrent winner'
     assert set(tmp_path.iterdir()) == entries_before | {target}

--- a/portalocker_tests/test_open_atomic.py
+++ b/portalocker_tests/test_open_atomic.py
@@ -117,7 +117,7 @@ def test_open_atomic_existing_destination_check_survives_optimization(
         pass
 
     script: str = textwrap.dedent(
-        f'''\
+        f"""\
         import pathlib
 
         import portalocker
@@ -135,7 +135,7 @@ def test_open_atomic_existing_destination_check_survives_optimization(
             raise RuntimeError('missing AssertionError under optimized Python')
         if target.read_bytes() != expected:
             raise RuntimeError('existing destination was modified')
-        ''',
+        """,
     )
     completed: subprocess.CompletedProcess[str] = subprocess.run(
         [sys.executable, '-O', '-c', script],

--- a/portalocker_tests/test_open_atomic.py
+++ b/portalocker_tests/test_open_atomic.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+import pathlib
+
+import pytest
+
+import portalocker
+
+
+def test_open_atomic_preserves_destination_created_before_publication(
+    tmp_path: pathlib.Path,
+) -> None:
+    target: pathlib.Path = tmp_path / 'destination.bin'
+    entries_before: set[pathlib.Path] = set(tmp_path.iterdir())
+
+    with pytest.raises(FileExistsError):
+        with portalocker.open_atomic(target) as temporary:
+            written: int = temporary.write(b'temporary payload')
+            assert written == len(b'temporary payload')
+            target.write_bytes(b'concurrent winner')
+
+    assert target.read_bytes() == b'concurrent winner'
+    assert set(tmp_path.iterdir()) == entries_before | {target}

--- a/portalocker_tests/test_open_atomic.py
+++ b/portalocker_tests/test_open_atomic.py
@@ -47,7 +47,7 @@ def test_open_atomic_uses_platform_publication_primitive(
         destination: pathlib.Path,
     ) -> None:
         raise AssertionError(
-            f'unexpected publication call: {source!r} -> {destination!r}'
+            f'unexpected publication call: {source!r} -> {destination!r}',
         )
 
     publication_function: str = 'rename' if os.name == 'nt' else 'link'

--- a/portalocker_tests/test_open_atomic.py
+++ b/portalocker_tests/test_open_atomic.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 import pathlib
 import subprocess
 import sys
@@ -8,6 +9,45 @@ import textwrap
 import pytest
 
 import portalocker
+
+
+def test_open_atomic_publishes_without_leaving_temporary_file(
+    tmp_path: pathlib.Path,
+) -> None:
+    target: pathlib.Path = tmp_path / 'destination.bin'
+    entries_before: set[pathlib.Path] = set(tmp_path.iterdir())
+
+    with portalocker.open_atomic(target) as temporary:
+        written: int = temporary.write(b'published payload')
+        assert written == len(b'published payload')
+
+    assert target.read_bytes() == b'published payload'
+    assert set(tmp_path.iterdir()) == entries_before | {target}
+
+
+def test_open_atomic_cleans_temporary_file_after_link_error(
+    tmp_path: pathlib.Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    target: pathlib.Path = tmp_path / 'destination.bin'
+    temporary_paths: list[pathlib.Path] = []
+
+    def fail_link(source: str, destination: pathlib.Path) -> None:
+        temporary_paths.append(pathlib.Path(source))
+        assert destination == target
+        raise OSError('link publication failed')
+
+    monkeypatch.setattr(os, 'link', fail_link)
+
+    with pytest.raises(OSError, match='link publication failed'):
+        with portalocker.open_atomic(target) as temporary:
+            written: int = temporary.write(b'unpublished payload')
+            assert written == len(b'unpublished payload')
+
+    assert len(temporary_paths) == 1
+    assert not temporary_paths[0].exists()
+    assert not target.exists()
+    assert not any(tmp_path.iterdir())
 
 
 def test_open_atomic_existing_destination_check_survives_optimization(

--- a/portalocker_tests/test_open_atomic.py
+++ b/portalocker_tests/test_open_atomic.py
@@ -1,10 +1,58 @@
 from __future__ import annotations
 
 import pathlib
+import subprocess
+import sys
+import textwrap
 
 import pytest
 
 import portalocker
+
+
+def test_open_atomic_existing_destination_check_survives_optimization(
+    tmp_path: pathlib.Path,
+) -> None:
+    target: pathlib.Path = tmp_path / 'destination.bin'
+    existing: bytes = b'existing destination'
+    expected_message: str = f'{target!r} exists'
+    target.write_bytes(existing)
+
+    with pytest.raises(AssertionError, match='exists'):
+        with portalocker.open_atomic(target):
+            pass
+
+    script: str = textwrap.dedent(
+        f'''\
+        import pathlib
+
+        import portalocker
+
+        target: pathlib.Path = pathlib.Path({str(target)!r})
+        expected: bytes = {existing!r}
+        expected_message: str = {expected_message!r}
+        try:
+            with portalocker.open_atomic(target):
+                pass
+        except AssertionError as error:
+            if str(error) != expected_message:
+                raise
+        else:
+            raise RuntimeError('missing AssertionError under optimized Python')
+        if target.read_bytes() != expected:
+            raise RuntimeError('existing destination was modified')
+        ''',
+    )
+    completed: subprocess.CompletedProcess[str] = subprocess.run(
+        [sys.executable, '-O', '-c', script],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    assert completed.stdout == ''
+    assert completed.stderr == ''
+    assert target.read_bytes() == existing
 
 
 def test_open_atomic_preserves_destination_created_before_publication(

--- a/portalocker_tests/test_open_atomic.py
+++ b/portalocker_tests/test_open_atomic.py
@@ -42,7 +42,10 @@ def test_open_atomic_uses_platform_publication_primitive(
         publication_calls.append((pathlib.Path(source), destination))
         real_replace(source, destination)
 
-    def fail_unused_publication(source: str, destination: pathlib.Path) -> None:
+    def fail_unused_publication(
+        source: str,
+        destination: pathlib.Path,
+    ) -> None:
         raise AssertionError(
             f'unexpected publication call: {source!r} -> {destination!r}'
         )
@@ -50,7 +53,11 @@ def test_open_atomic_uses_platform_publication_primitive(
     publication_function: str = 'rename' if os.name == 'nt' else 'link'
     unused_publication_function: str = 'link' if os.name == 'nt' else 'rename'
     monkeypatch.setattr(os, publication_function, fake_publication)
-    monkeypatch.setattr(os, unused_publication_function, fail_unused_publication)
+    monkeypatch.setattr(
+        os,
+        unused_publication_function,
+        fail_unused_publication,
+    )
 
     with portalocker.open_atomic(target) as file_handle:
         temporary: typing.BinaryIO = typing.cast(typing.BinaryIO, file_handle)

--- a/portalocker_tests/test_open_atomic.py
+++ b/portalocker_tests/test_open_atomic.py
@@ -5,6 +5,7 @@ import pathlib
 import subprocess
 import sys
 import textwrap
+import typing
 
 import pytest
 
@@ -17,7 +18,8 @@ def test_open_atomic_publishes_without_leaving_temporary_file(
     target: pathlib.Path = tmp_path / 'destination.bin'
     entries_before: set[pathlib.Path] = set(tmp_path.iterdir())
 
-    with portalocker.open_atomic(target) as temporary:
+    with portalocker.open_atomic(target) as file_handle:
+        temporary: typing.BinaryIO = typing.cast(typing.BinaryIO, file_handle)
         written: int = temporary.write(b'published payload')
         assert written == len(b'published payload')
 
@@ -40,7 +42,11 @@ def test_open_atomic_cleans_temporary_file_after_link_error(
     monkeypatch.setattr(os, 'link', fail_link)
 
     with pytest.raises(OSError, match='link publication failed'):
-        with portalocker.open_atomic(target) as temporary:
+        with portalocker.open_atomic(target) as file_handle:
+            temporary: typing.BinaryIO = typing.cast(
+                typing.BinaryIO,
+                file_handle,
+            )
             written: int = temporary.write(b'unpublished payload')
             assert written == len(b'unpublished payload')
 
@@ -102,7 +108,11 @@ def test_open_atomic_preserves_destination_created_before_publication(
     entries_before: set[pathlib.Path] = set(tmp_path.iterdir())
 
     with pytest.raises(FileExistsError):
-        with portalocker.open_atomic(target) as temporary:
+        with portalocker.open_atomic(target) as file_handle:
+            temporary: typing.BinaryIO = typing.cast(
+                typing.BinaryIO,
+                file_handle,
+            )
             written: int = temporary.write(b'temporary payload')
             assert written == len(b'temporary payload')
             target.write_bytes(b'concurrent winner')

--- a/portalocker_tests/test_open_atomic.py
+++ b/portalocker_tests/test_open_atomic.py
@@ -27,21 +27,55 @@ def test_open_atomic_publishes_without_leaving_temporary_file(
     assert set(tmp_path.iterdir()) == entries_before | {target}
 
 
-def test_open_atomic_cleans_temporary_file_after_link_error(
+def test_open_atomic_uses_rename_on_windows(
+    tmp_path: pathlib.Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    target: pathlib.Path = tmp_path / 'destination.bin'
+    rename_calls: list[tuple[pathlib.Path, pathlib.Path]] = []
+    real_replace: typing.Callable[[str, pathlib.Path], None] = typing.cast(
+        typing.Callable[[str, pathlib.Path], None],
+        os.replace,
+    )
+
+    def fake_rename(source: str, destination: pathlib.Path) -> None:
+        rename_calls.append((pathlib.Path(source), destination))
+        real_replace(source, destination)
+
+    def fail_link(source: str, destination: pathlib.Path) -> None:
+        raise AssertionError(f'unexpected os.link({source!r}, {destination!r})')
+
+    monkeypatch.setattr(os, 'name', 'nt')
+    monkeypatch.setattr(os, 'rename', fake_rename)
+    monkeypatch.setattr(os, 'link', fail_link)
+
+    with portalocker.open_atomic(target) as file_handle:
+        temporary: typing.BinaryIO = typing.cast(typing.BinaryIO, file_handle)
+        written: int = temporary.write(b'published with rename')
+        assert written == len(b'published with rename')
+
+    assert target.read_bytes() == b'published with rename'
+    assert len(rename_calls) == 1
+    assert rename_calls[0][1] == target
+    assert not rename_calls[0][0].exists()
+
+
+def test_open_atomic_cleans_temporary_file_after_publication_error(
     tmp_path: pathlib.Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     target: pathlib.Path = tmp_path / 'destination.bin'
     temporary_paths: list[pathlib.Path] = []
 
-    def fail_link(source: str, destination: pathlib.Path) -> None:
+    def fail_publication(source: str, destination: pathlib.Path) -> None:
         temporary_paths.append(pathlib.Path(source))
         assert destination == target
-        raise OSError('link publication failed')
+        raise OSError('publication failed')
 
-    monkeypatch.setattr(os, 'link', fail_link)
+    publication_function: str = 'rename' if os.name == 'nt' else 'link'
+    monkeypatch.setattr(os, publication_function, fail_publication)
 
-    with pytest.raises(OSError, match='link publication failed'):
+    with pytest.raises(OSError, match='publication failed'):
         with portalocker.open_atomic(target) as file_handle:
             temporary: typing.BinaryIO = typing.cast(
                 typing.BinaryIO,


### PR DESCRIPTION
## Summary

- publish synchronized temporary files with `os.link()` so a concurrently created destination wins instead of being replaced
- preserve the existing entry-time `AssertionError` under optimized Python
- document the create-if-absent contract and cover successful publication, collisions, optimized mode, and cleanup

## Root cause

`open_atomic()` checked destination absence only before yielding, then called `os.rename()`. On POSIX, that final rename atomically replaced a destination created while the context was open. The check was also an `assert`, so `python -O` removed it.

## Impact

Valid create-if-absent calls retain the same API and result. An existing destination at entry still raises `AssertionError`; a destination that wins the publication race now remains untouched and causes `FileExistsError`. Filesystems without hard-link support fail closed with their original `OSError` instead of falling back to replacement.

## Validation

- `uv run pytest` (100% coverage gate)
- `uv run mypy`
- `uv run basedpyright`
- `uv run pyrefly check`
- `uv run ty check`
- `uv run codespell`
- `uv run sphinx-build -W -b html docs docs/_build/html`
- `uv build`

Fixes #114