### PR TITLE
Add opt-in release error reporting

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -43,8 +43,10 @@
    ``LockException`` per the documented contract
  * ``RedisLock`` tests now run everywhere via ``fakeredis``, with a live
    Redis server still tested in CI
- * ``Lock.release()`` no longer propagates unlock errors; the file handle is
-   always closed and cleared so a release can never leave a dangling lock
+ * ``Lock.release()`` continues suppressing unlock and close errors by default;
+   closing is always attempted and the file handle reference is cleared.
+   Callers can opt into reporting cleanup failures with
+   ``Lock(..., raise_on_release_error=True)`` (#117)
  * ``TemporaryFileLock.release()`` and ``PidFileLock.release()`` are now
    no-ops when the object does not hold the lock, so a stale object (double
    release, or garbage collection of a failed acquire) can no longer unlink
@@ -122,4 +124,3 @@ https://github.com/WoLpH/portalocker/commits/master
 0.1:
 
  * Initial release
-

--- a/docs/superpowers/plans/2026-07-16-release-error-policy.md
+++ b/docs/superpowers/plans/2026-07-16-release-error-policy.md
@@ -1,0 +1,409 @@
+# Release Error Policy Implementation Plan
+
+**For agentic workers:** REQUIRED SUB-SKILL: Use
+superpowers:subagent-driven-development (recommended) or
+superpowers:executing-plans to implement this plan task-by-task. Steps use
+checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add opt-in reporting of `Lock.release()` failures without changing
+the default behavior shipped in portalocker 3.3.0.
+
+**Architecture:** `Lock` stores a keyword-only release-error policy. Its
+release path always attempts unlock and close, then either suppresses collected
+ordinary exceptions or raises them according to that policy. A `Lock`-specific
+context exit path preserves protected-body exceptions only when strict release
+handling was explicitly enabled, leaving `LockBase` and subclass defaults
+unchanged.
+
+**Tech Stack:** Python 3.10+, pytest, uv, tox, Sphinx/reStructuredText.
+
+---
+
+### Task 1: Fault-injection coverage for direct release
+
+**Files:**
+
+- Create: `portalocker_tests/test_release_errors.py`
+- Modify: `portalocker/utils.py:197-349`
+
+- [ ] **Step 1: Write the direct-release tests**
+
+Create `portalocker_tests/test_release_errors.py` with a small real fake handle
+that records close attempts and optionally raises a supplied exception:
+
+```python
+from __future__ import annotations
+
+import typing
+
+import pytest
+
+from portalocker import types, utils
+
+
+class ReleaseHandle:
+    def __init__(
+        self,
+        events: list[str],
+        close_error: Exception | None = None,
+    ) -> None:
+        self.events = events
+        self.close_error = close_error
+
+    def close(self) -> None:
+        self.events.append('close')
+        if self.close_error is not None:
+            raise self.close_error
+
+
+def make_lock(
+    handle: ReleaseHandle,
+    *,
+    raise_on_release_error: bool = False,
+) -> utils.Lock:
+    lock = utils.Lock(
+        'unused.lock',
+        raise_on_release_error=raise_on_release_error,
+    )
+    lock.fh = typing.cast(types.IO, handle)
+    return lock
+
+
+def set_unlock(
+    monkeypatch: pytest.MonkeyPatch,
+    events: list[str],
+    error: Exception | None = None,
+) -> None:
+    def unlock(_fh: types.IO) -> None:
+        events.append('unlock')
+        if error is not None:
+            raise error
+
+    monkeypatch.setattr(utils.portalocker, 'unlock', unlock)
+
+
+def test_release_suppresses_errors_by_default(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    events: list[str] = []
+    unlock_error = OSError('unlock failed')
+    close_error = OSError('close failed')
+    handle = ReleaseHandle(events, close_error)
+    lock = make_lock(handle)
+    set_unlock(monkeypatch, events, unlock_error)
+
+    lock.release()
+
+    assert events == ['unlock', 'close']
+    assert lock.fh is None
+
+
+def test_strict_release_raises_unlock_error_after_closing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    events: list[str] = []
+    unlock_error = OSError('unlock failed')
+    handle = ReleaseHandle(events)
+    lock = make_lock(handle, raise_on_release_error=True)
+    set_unlock(monkeypatch, events, unlock_error)
+
+    with pytest.raises(OSError) as exc_info:
+        lock.release()
+
+    assert exc_info.value is unlock_error
+    assert events == ['unlock', 'close']
+    assert lock.fh is None
+
+
+def test_strict_release_raises_close_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    events: list[str] = []
+    close_error = OSError('close failed')
+    handle = ReleaseHandle(events, close_error)
+    lock = make_lock(handle, raise_on_release_error=True)
+    set_unlock(monkeypatch, events)
+
+    with pytest.raises(OSError) as exc_info:
+        lock.release()
+
+    assert exc_info.value is close_error
+    assert events == ['unlock', 'close']
+    assert lock.fh is None
+
+
+def test_strict_release_chains_close_error_to_unlock_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    events: list[str] = []
+    unlock_error = OSError('unlock failed')
+    close_error = OSError('close failed')
+    handle = ReleaseHandle(events, close_error)
+    lock = make_lock(handle, raise_on_release_error=True)
+    set_unlock(monkeypatch, events, unlock_error)
+
+    with pytest.raises(OSError) as exc_info:
+        lock.release()
+
+    assert exc_info.value is unlock_error
+    assert exc_info.value.__cause__ is close_error
+    assert events == ['unlock', 'close']
+    assert lock.fh is None
+```
+
+- [ ] **Step 2: Run the strict tests and verify RED**
+
+Run:
+
+```bash
+uv run pytest portalocker_tests/test_release_errors.py -q --no-cov
+```
+
+Expected: the default-compatibility test passes, while strict tests fail because
+release errors are still suppressed.
+
+- [ ] **Step 3: Add the policy and direct-release implementation**
+
+In `portalocker/utils.py`, document and store the new keyword-only argument:
+
+```diff
+ class Lock(LockBase[typing.IO[typing.Any]]):
++    raise_on_release_error: bool
+
+     def __init__(
+         self,
+         filename: Filename,
+         mode: Mode = 'a',
+         timeout: float | None = None,
+         check_interval: float = DEFAULT_CHECK_INTERVAL,
+         fail_when_locked: bool = DEFAULT_FAIL_WHEN_LOCKED,
+         flags: constants.LockFlags = LOCK_METHOD,
++        *,
++        raise_on_release_error: bool = False,
+         **file_open_kwargs: typing.Any,
+     ) -> None:
+         self.fh = None
+         self.filename = str(filename)
+         self.mode = mode
+         self.truncate = truncate
+         self.flags = flags
++        self.raise_on_release_error = raise_on_release_error
+         self.file_open_kwargs = file_open_kwargs
+```
+
+Replace `Lock.release()` with collection logic that preserves current
+`BaseException` behavior:
+
+```python
+    def release(self) -> None:
+        """Release the currently locked file handle."""
+        fh = self.fh
+        if fh:
+            release_errors: list[Exception] = []
+            try:
+                try:
+                    portalocker.unlock(fh)
+                except Exception as exception:
+                    release_errors.append(exception)
+            finally:
+                try:
+                    fh.close()
+                except Exception as exception:
+                    release_errors.append(exception)
+                self.fh = None
+
+            if self.raise_on_release_error and release_errors:
+                primary_error = release_errors[0]
+                if len(release_errors) > 1:
+                    raise primary_error from release_errors[1]
+                raise primary_error
+```
+
+Add `raise_on_release_error` to the class docstring, explaining that `False`
+preserves best-effort suppression and `True` raises only after unlock and close
+have both been attempted.
+
+- [ ] **Step 4: Run the direct-release tests and verify GREEN**
+
+Run:
+
+```bash
+uv run pytest portalocker_tests/test_release_errors.py -q --no-cov
+```
+
+Expected: 4 passed.
+
+- [ ] **Step 5: Commit the direct-release behavior**
+
+```bash
+git add portalocker/utils.py portalocker_tests/test_release_errors.py
+git commit -m "add opt-in release error reporting"
+```
+
+### Task 2: Preserve protected-body exceptions in strict contexts
+
+**Files:**
+
+- Modify: `portalocker_tests/test_release_errors.py`
+- Modify: `portalocker/utils.py:334-349`
+
+- [ ] **Step 1: Add strict context-manager tests**
+
+Append:
+
+```python
+def test_strict_context_exit_raises_release_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    events: list[str] = []
+    unlock_error = OSError('unlock failed')
+    handle = ReleaseHandle(events)
+    lock = make_lock(handle, raise_on_release_error=True)
+    set_unlock(monkeypatch, events, unlock_error)
+
+    with pytest.raises(OSError) as exc_info:
+        with lock:
+            pass
+
+    assert exc_info.value is unlock_error
+    assert events == ['unlock', 'close']
+
+
+def test_strict_context_preserves_body_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    events: list[str] = []
+    body_error = ValueError('body failed')
+    unlock_error = OSError('unlock failed')
+    handle = ReleaseHandle(events)
+    lock = make_lock(handle, raise_on_release_error=True)
+    set_unlock(monkeypatch, events, unlock_error)
+
+    with pytest.raises(ValueError) as exc_info:
+        with lock:
+            raise body_error
+
+    assert exc_info.value is body_error
+    assert exc_info.value.__context__ is unlock_error
+    assert events == ['unlock', 'close']
+```
+
+- [ ] **Step 2: Run the body-error test and verify RED**
+
+Run:
+
+```bash
+uv run pytest \
+  portalocker_tests/test_release_errors.py::test_strict_context_preserves_body_error \
+  -q --no-cov
+```
+
+Expected: FAIL because the release error replaces the protected-body error.
+
+- [ ] **Step 3: Override `Lock.__exit__()` only for explicit strict mode**
+
+Add after `Lock.__enter__()`:
+
+```python
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_value: BaseException | None,
+        traceback: typing.Any,
+    ) -> bool | None:
+        if not self.raise_on_release_error or exc_value is None:
+            self.release()
+            return None
+
+        try:
+            self.release()
+        except Exception as release_error:
+            previous_context = exc_value.__context__
+            release_error.__context__ = previous_context
+            exc_value.__context__ = release_error
+            add_note: typing.Callable[[str], None] | None = getattr(
+                exc_value,
+                'add_note',
+                None,
+            )
+            if add_note is not None:
+                add_note(f'portalocker release failed: {release_error!r}')
+        return None
+```
+
+This branch is unreachable under default settings. It also avoids changing
+`LockBase.__exit__()` and the cleanup semantics of other lock types.
+
+- [ ] **Step 4: Run focused and core locking tests**
+
+Run:
+
+```bash
+uv run pytest \
+  portalocker_tests/test_release_errors.py \
+  portalocker_tests/test_core_locking.py \
+  portalocker_tests/test_rlock_behaviour.py \
+  portalocker_tests/test_temporary_file_lock.py \
+  -q --no-cov
+```
+
+Expected: all selected tests pass. Full coverage enforcement runs in Task 3.
+
+- [ ] **Step 5: Commit context behavior**
+
+```bash
+git add portalocker/utils.py portalocker_tests/test_release_errors.py
+git commit -m "preserve body errors during strict release"
+```
+
+### Task 3: Document and verify the compatibility policy
+
+**Files:**
+
+- Modify: `CHANGELOG.rst:46-47`
+- Verify: `portalocker/utils.py`
+- Verify: `portalocker_tests/test_release_errors.py`
+
+- [ ] **Step 1: Extend the 4.0 changelog entry**
+
+Change the existing release bullet to:
+
+```rst
+ * ``Lock.release()`` continues suppressing unlock and close errors by default;
+   closing is always attempted and the file handle reference is cleared.
+   Callers can opt into reporting cleanup failures with
+   ``Lock(..., raise_on_release_error=True)`` (#117)
+```
+
+- [ ] **Step 2: Run the complete project verification**
+
+Run:
+
+```bash
+uv run pytest
+uv run tox -p auto
+```
+
+Expected: all tests, type checkers, lint/format checks, spelling checks,
+package checks, and documentation builds pass.
+
+- [ ] **Step 3: Inspect the final diff for scope and compatibility**
+
+Run:
+
+```bash
+git diff --check HEAD~2
+git diff --stat HEAD~2
+git status --short
+```
+
+Confirm only `portalocker/utils.py`, the focused test module, and
+`CHANGELOG.rst` contain implementation changes. Confirm the worktree is clean
+apart from the ignored environment/lock artifacts.
+
+- [ ] **Step 4: Commit the documentation**
+
+```bash
+git add CHANGELOG.rst
+git commit -m "document strict release error handling"
+```

--- a/docs/superpowers/plans/2026-07-16-release-error-policy.md
+++ b/docs/superpowers/plans/2026-07-16-release-error-policy.md
@@ -321,13 +321,10 @@ Add after `Lock.__enter__()`:
             previous_context = exc_value.__context__
             release_error.__context__ = previous_context
             exc_value.__context__ = release_error
-            exception_notes: list[str] = typing.cast(
-                list[str],
-                exc_value.__dict__.setdefault('__notes__', []),
-            )
-            exception_notes.append(
-                f'portalocker release failed: {release_error!r}',
-            )
+            with contextlib.suppress(Exception):
+                exc_value.add_note(  # type: ignore[attr-defined]  # ty: ignore[unresolved-attribute]
+                    'portalocker release failed; see exception context',
+                )
         return None
 ```
 

--- a/docs/superpowers/plans/2026-07-16-release-error-policy.md
+++ b/docs/superpowers/plans/2026-07-16-release-error-policy.md
@@ -321,13 +321,13 @@ Add after `Lock.__enter__()`:
             previous_context = exc_value.__context__
             release_error.__context__ = previous_context
             exc_value.__context__ = release_error
-            add_note: typing.Callable[[str], None] | None = getattr(
-                exc_value,
-                'add_note',
-                None,
+            exception_notes: list[str] = typing.cast(
+                list[str],
+                exc_value.__dict__.setdefault('__notes__', []),
             )
-            if add_note is not None:
-                add_note(f'portalocker release failed: {release_error!r}')
+            exception_notes.append(
+                f'portalocker release failed: {release_error!r}',
+            )
         return None
 ```
 

--- a/docs/superpowers/specs/2026-07-15-release-error-policy-design.md
+++ b/docs/superpowers/specs/2026-07-15-release-error-policy-design.md
@@ -1,0 +1,81 @@
+# Release Error Policy Design
+
+## Goal
+
+Make `Lock.release()` cleanup failures observable for callers that explicitly
+request strict handling, while preserving the behavior of portalocker 3.3.0 by
+default.
+
+## Compatibility Contract
+
+`Lock` gains a keyword-only `raise_on_release_error: bool = False` constructor
+argument. The default remains best-effort cleanup: ordinary exceptions from
+unlocking or closing are suppressed, both operations are attempted, and the
+file-handle reference is cleared. Existing callers therefore retain the current
+PyPI behavior without source changes.
+
+Strict behavior is opt-in. Setting `raise_on_release_error=True` makes cleanup
+failures observable without changing acquisition, successful release, repeated
+release, finalizer, or subclass defaults.
+
+## Release Behavior
+
+`Lock.release()` captures ordinary `Exception` instances raised by
+`portalocker.unlock()` and the file handle's `close()` method. Closing is still
+attempted after an unlock failure. After both attempts, `self.fh` is cleared as
+it is today.
+
+With the default policy, captured errors are discarded. With strict handling,
+the first captured error is raised unchanged. If both operations fail, the
+close error is attached as the explicit cause of the unlock error, retaining
+both exception objects on every supported Python version.
+
+Handling of `BaseException` subclasses remains unchanged. They are not captured
+as release errors, matching the existing `contextlib.suppress(Exception)`
+boundary.
+
+## Context Manager Behavior
+
+`Lock.__exit__()` applies the same policy. With no protected-body exception, a
+strict release error propagates normally. When the protected body and strict
+release both fail, the protected-body exception remains the exception observed
+by the caller. The release error is retained as secondary exception context;
+on Python versions providing `BaseException.add_note()`, a concise cleanup note
+is also added for traceback visibility.
+
+Default context-manager behavior remains unchanged because release errors are
+suppressed unless strict handling was requested.
+
+`LockBase.__exit__()` is not changed, avoiding behavioral changes to Redis,
+semaphore, or third-party `LockBase` subclasses.
+
+## Finalization and Subclasses
+
+`LockBase.__del__()` continues suppressing release failures because garbage
+collection cannot safely surface them.
+
+`RLock`, `TemporaryFileLock`, and `PidFileLock` retain their current constructor
+signatures and default behavior. The new policy is initially exposed only on
+`Lock`, matching issue #117 and minimizing public API expansion. Subclass
+support can be added separately if a concrete need emerges.
+
+## Documentation
+
+The `Lock` class docstring documents the new argument and strict-mode semantics.
+The 4.0 changelog records that release errors can now be observed explicitly
+while the default remains compatible with portalocker 3.3.0.
+
+## Tests
+
+Focused tests cover:
+
+- default suppression when unlock and close both fail;
+- strict unlock-only failure, including the close attempt;
+- strict close-only failure;
+- strict dual failure with unlock primary and close as its cause;
+- strict context exit without a protected-body exception;
+- strict context exit preserving a protected-body exception as primary;
+- successful and repeated release behavior remaining unchanged.
+
+The full test and static-check suite verifies no regression outside the focused
+release paths.

--- a/portalocker/utils.py
+++ b/portalocker/utils.py
@@ -356,13 +356,10 @@ class Lock(LockBase[typing.IO[typing.Any]]):
             previous_context: BaseException | None = exc_value.__context__
             release_error.__context__ = previous_context
             exc_value.__context__ = release_error
-            exception_notes: list[str] = typing.cast(
-                list[str],
-                exc_value.__dict__.setdefault('__notes__', []),
-            )
-            exception_notes.append(
-                f'portalocker release failed: {release_error!r}',
-            )
+            with contextlib.suppress(Exception):
+                exc_value.add_note(  # type: ignore[attr-defined]  # ty: ignore[unresolved-attribute]
+                    'portalocker release failed; see exception context',
+                )
         return None
 
     def release(self) -> None:

--- a/portalocker/utils.py
+++ b/portalocker/utils.py
@@ -209,6 +209,8 @@ class Lock(LockBase[typing.IO[typing.Any]]):
             (``LockFlags.SHARED``) on Windows require the optional
             ``pywin32`` package (``pip install "portalocker[win32]"``);
             without it, acquiring a shared lock raises ``ImportError``.
+        raise_on_release_error: raise cleanup errors after both unlocking and
+            closing have been attempted. Disabled by default for compatibility.
         **file_open_kwargs: The kwargs for the `open(...)` call
 
     fail_when_locked is useful when multiple threads/processes can race
@@ -227,6 +229,7 @@ class Lock(LockBase[typing.IO[typing.Any]]):
     check_interval: float
     fail_when_locked: bool
     flags: constants.LockFlags
+    raise_on_release_error: bool
     file_open_kwargs: dict[str, typing.Any]
 
     def __init__(
@@ -237,6 +240,8 @@ class Lock(LockBase[typing.IO[typing.Any]]):
         check_interval: float = DEFAULT_CHECK_INTERVAL,
         fail_when_locked: bool = DEFAULT_FAIL_WHEN_LOCKED,
         flags: constants.LockFlags = LOCK_METHOD,
+        *,
+        raise_on_release_error: bool = False,
         **file_open_kwargs: typing.Any,
     ) -> None:
         if 'w' in mode:
@@ -258,6 +263,7 @@ class Lock(LockBase[typing.IO[typing.Any]]):
         self.mode = mode
         self.truncate = truncate
         self.flags = flags
+        self.raise_on_release_error = raise_on_release_error
         self.file_open_kwargs = file_open_kwargs
         super().__init__(timeout, check_interval, fail_when_locked)
 
@@ -335,18 +341,30 @@ class Lock(LockBase[typing.IO[typing.Any]]):
         return self.acquire()
 
     def release(self) -> None:
-        """Releases the currently locked file handle"""
-        if self.fh:
+        """Release the currently locked file handle."""
+        fh = self.fh
+        if fh:
+            release_errors: list[Exception] = []
             # On Windows, closing the handle also releases the lock. Ensure we
             # always close, even if unlock raises due to edge cases when
             # preparing/restoring file position.
             try:
-                with contextlib.suppress(Exception):
-                    portalocker.unlock(self.fh)
+                try:
+                    portalocker.unlock(fh)
+                except Exception as exception:
+                    release_errors.append(exception)
             finally:
-                with contextlib.suppress(Exception):
-                    self.fh.close()
+                try:
+                    fh.close()
+                except Exception as exception:
+                    release_errors.append(exception)
                 self.fh = None
+
+            if self.raise_on_release_error and release_errors:
+                primary_error: Exception = release_errors[0]
+                if len(release_errors) > 1:
+                    raise primary_error from release_errors[1]
+                raise primary_error
 
     def _get_fh(self) -> types.IO:
         """Get a new filehandle"""

--- a/portalocker/utils.py
+++ b/portalocker/utils.py
@@ -340,6 +340,31 @@ class Lock(LockBase[typing.IO[typing.Any]]):
     def __enter__(self) -> typing.IO[typing.Any]:
         return self.acquire()
 
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_value: BaseException | None,
+        traceback: typing.Any,
+    ) -> bool | None:
+        if not self.raise_on_release_error or exc_value is None:
+            self.release()
+            return None
+
+        try:
+            self.release()
+        except Exception as release_error:
+            previous_context: BaseException | None = exc_value.__context__
+            release_error.__context__ = previous_context
+            exc_value.__context__ = release_error
+            add_note: typing.Callable[[str], None] | None = getattr(
+                exc_value,
+                'add_note',
+                None,
+            )
+            if add_note is not None:
+                add_note(f'portalocker release failed: {release_error!r}')
+        return None
+
     def release(self) -> None:
         """Release the currently locked file handle."""
         fh = self.fh

--- a/portalocker/utils.py
+++ b/portalocker/utils.py
@@ -356,13 +356,13 @@ class Lock(LockBase[typing.IO[typing.Any]]):
             previous_context: BaseException | None = exc_value.__context__
             release_error.__context__ = previous_context
             exc_value.__context__ = release_error
-            add_note: typing.Callable[[str], None] | None = getattr(
-                exc_value,
-                'add_note',
-                None,
+            exception_notes: list[str] = typing.cast(
+                list[str],
+                exc_value.__dict__.setdefault('__notes__', []),
             )
-            if add_note is not None:
-                add_note(f'portalocker release failed: {release_error!r}')
+            exception_notes.append(
+                f'portalocker release failed: {release_error!r}',
+            )
         return None
 
     def release(self) -> None:

--- a/portalocker_tests/test_release_errors.py
+++ b/portalocker_tests/test_release_errors.py
@@ -4,6 +4,7 @@ import typing
 
 import pytest
 
+import portalocker.portalocker as portalocker_module
 from portalocker import types, utils
 
 
@@ -45,7 +46,7 @@ def set_unlock(
         if error is not None:
             raise error
 
-    monkeypatch.setattr(utils.portalocker, 'unlock', unlock)
+    monkeypatch.setattr(portalocker_module, 'unlock', unlock)
 
 
 def test_release_suppresses_errors_by_default(
@@ -130,9 +131,8 @@ def test_strict_context_exit_raises_release_error(
     set_unlock(monkeypatch, events, unlock_error)
 
     exc_info: pytest.ExceptionInfo[OSError]
-    with pytest.raises(OSError) as exc_info:
-        with lock:
-            pass
+    with pytest.raises(OSError) as exc_info, lock:
+        pass
 
     assert exc_info.value is unlock_error
     assert events == ['unlock', 'close']
@@ -149,10 +149,16 @@ def test_strict_context_preserves_body_error(
     set_unlock(monkeypatch, events, unlock_error)
 
     exc_info: pytest.ExceptionInfo[ValueError]
-    with pytest.raises(ValueError) as exc_info:
-        with lock:
-            raise body_error
+    with pytest.raises(ValueError) as exc_info, lock:
+        raise body_error
 
     assert exc_info.value is body_error
     assert exc_info.value.__context__ is unlock_error
+    exception_notes: list[str] = typing.cast(
+        list[str],
+        exc_info.value.__dict__['__notes__'],
+    )
+    assert exception_notes == [
+        "portalocker release failed: OSError('unlock failed')",
+    ]
     assert events == ['unlock', 'close']

--- a/portalocker_tests/test_release_errors.py
+++ b/portalocker_tests/test_release_errors.py
@@ -160,15 +160,11 @@ def test_strict_context_preserves_body_error(
     assert exc_info.value is body_error
     assert exc_info.value.__context__ is unlock_error
     if hasattr(exc_info.value, 'add_note'):
-        exception_notes: list[str] = typing.cast(
-            list[str],
-            exc_info.value.__dict__['__notes__'],
-        )
-        assert exception_notes == [
+        assert getattr(exc_info.value, '__notes__', []) == [
             'portalocker release failed; see exception context',
         ]
     else:
-        assert '__notes__' not in exc_info.value.__dict__
+        assert not hasattr(exc_info.value, '__notes__')
     assert events == ['unlock', 'close']
 
 

--- a/portalocker_tests/test_release_errors.py
+++ b/portalocker_tests/test_release_errors.py
@@ -159,13 +159,16 @@ def test_strict_context_preserves_body_error(
 
     assert exc_info.value is body_error
     assert exc_info.value.__context__ is unlock_error
-    exception_notes: list[str] = typing.cast(
-        list[str],
-        exc_info.value.__dict__['__notes__'],
-    )
-    assert exception_notes == [
-        'portalocker release failed; see exception context',
-    ]
+    if hasattr(exc_info.value, 'add_note'):
+        exception_notes: list[str] = typing.cast(
+            list[str],
+            exc_info.value.__dict__['__notes__'],
+        )
+        assert exception_notes == [
+            'portalocker release failed; see exception context',
+        ]
+    else:
+        assert '__notes__' not in exc_info.value.__dict__
     assert events == ['unlock', 'close']
 
 

--- a/portalocker_tests/test_release_errors.py
+++ b/portalocker_tests/test_release_errors.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+import typing
+
+import pytest
+
+from portalocker import types, utils
+
+
+class ReleaseHandle:
+    def __init__(
+        self,
+        events: list[str],
+        close_error: Exception | None = None,
+    ) -> None:
+        self.events: list[str] = events
+        self.close_error: Exception | None = close_error
+
+    def close(self) -> None:
+        self.events.append('close')
+        if self.close_error is not None:
+            raise self.close_error
+
+
+def make_lock(
+    handle: ReleaseHandle,
+    *,
+    raise_on_release_error: bool = False,
+) -> utils.Lock:
+    lock: utils.Lock = utils.Lock(
+        'unused.lock',
+        raise_on_release_error=raise_on_release_error,
+    )
+    lock.fh = typing.cast(types.IO, handle)
+    return lock
+
+
+def set_unlock(
+    monkeypatch: pytest.MonkeyPatch,
+    events: list[str],
+    error: Exception | None = None,
+) -> None:
+    def unlock(_fh: types.IO) -> None:
+        events.append('unlock')
+        if error is not None:
+            raise error
+
+    monkeypatch.setattr(utils.portalocker, 'unlock', unlock)
+
+
+def test_release_suppresses_errors_by_default(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    events: list[str] = []
+    unlock_error: OSError = OSError('unlock failed')
+    close_error: OSError = OSError('close failed')
+    handle: ReleaseHandle = ReleaseHandle(events, close_error)
+    lock: utils.Lock = make_lock(handle)
+    set_unlock(monkeypatch, events, unlock_error)
+
+    lock.release()
+
+    assert events == ['unlock', 'close']
+    assert lock.fh is None
+
+
+def test_strict_release_raises_unlock_error_after_closing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    events: list[str] = []
+    unlock_error: OSError = OSError('unlock failed')
+    handle: ReleaseHandle = ReleaseHandle(events)
+    lock: utils.Lock = make_lock(handle, raise_on_release_error=True)
+    set_unlock(monkeypatch, events, unlock_error)
+
+    exc_info: pytest.ExceptionInfo[OSError]
+    with pytest.raises(OSError) as exc_info:
+        lock.release()
+
+    assert exc_info.value is unlock_error
+    assert events == ['unlock', 'close']
+    assert lock.fh is None
+
+
+def test_strict_release_raises_close_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    events: list[str] = []
+    close_error: OSError = OSError('close failed')
+    handle: ReleaseHandle = ReleaseHandle(events, close_error)
+    lock: utils.Lock = make_lock(handle, raise_on_release_error=True)
+    set_unlock(monkeypatch, events)
+
+    exc_info: pytest.ExceptionInfo[OSError]
+    with pytest.raises(OSError) as exc_info:
+        lock.release()
+
+    assert exc_info.value is close_error
+    assert events == ['unlock', 'close']
+    assert lock.fh is None
+
+
+def test_strict_release_chains_close_error_to_unlock_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    events: list[str] = []
+    unlock_error: OSError = OSError('unlock failed')
+    close_error: OSError = OSError('close failed')
+    handle: ReleaseHandle = ReleaseHandle(events, close_error)
+    lock: utils.Lock = make_lock(handle, raise_on_release_error=True)
+    set_unlock(monkeypatch, events, unlock_error)
+
+    exc_info: pytest.ExceptionInfo[OSError]
+    with pytest.raises(OSError) as exc_info:
+        lock.release()
+
+    assert exc_info.value is unlock_error
+    assert exc_info.value.__cause__ is close_error
+    assert events == ['unlock', 'close']
+    assert lock.fh is None

--- a/portalocker_tests/test_release_errors.py
+++ b/portalocker_tests/test_release_errors.py
@@ -118,3 +118,41 @@ def test_strict_release_chains_close_error_to_unlock_error(
     assert exc_info.value.__cause__ is close_error
     assert events == ['unlock', 'close']
     assert lock.fh is None
+
+
+def test_strict_context_exit_raises_release_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    events: list[str] = []
+    unlock_error: OSError = OSError('unlock failed')
+    handle: ReleaseHandle = ReleaseHandle(events)
+    lock: utils.Lock = make_lock(handle, raise_on_release_error=True)
+    set_unlock(monkeypatch, events, unlock_error)
+
+    exc_info: pytest.ExceptionInfo[OSError]
+    with pytest.raises(OSError) as exc_info:
+        with lock:
+            pass
+
+    assert exc_info.value is unlock_error
+    assert events == ['unlock', 'close']
+
+
+def test_strict_context_preserves_body_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    events: list[str] = []
+    body_error: ValueError = ValueError('body failed')
+    unlock_error: OSError = OSError('unlock failed')
+    handle: ReleaseHandle = ReleaseHandle(events)
+    lock: utils.Lock = make_lock(handle, raise_on_release_error=True)
+    set_unlock(monkeypatch, events, unlock_error)
+
+    exc_info: pytest.ExceptionInfo[ValueError]
+    with pytest.raises(ValueError) as exc_info:
+        with lock:
+            raise body_error
+
+    assert exc_info.value is body_error
+    assert exc_info.value.__context__ is unlock_error
+    assert events == ['unlock', 'close']

--- a/portalocker_tests/test_release_errors.py
+++ b/portalocker_tests/test_release_errors.py
@@ -23,6 +23,11 @@ class ReleaseHandle:
             raise self.close_error
 
 
+class BrokenReprError(OSError):
+    def __repr__(self) -> str:
+        raise RuntimeError('repr failed')
+
+
 def make_lock(
     handle: ReleaseHandle,
     *,
@@ -159,6 +164,96 @@ def test_strict_context_preserves_body_error(
         exc_info.value.__dict__['__notes__'],
     )
     assert exception_notes == [
-        "portalocker release failed: OSError('unlock failed')",
+        'portalocker release failed; see exception context',
     ]
+    assert events == ['unlock', 'close']
+
+
+def test_strict_context_preserves_body_when_release_repr_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    events: list[str] = []
+    body_error: ValueError = ValueError('body failed')
+    unlock_error: BrokenReprError = BrokenReprError('unlock failed')
+    handle: ReleaseHandle = ReleaseHandle(events)
+    lock: utils.Lock = make_lock(handle, raise_on_release_error=True)
+    set_unlock(monkeypatch, events, unlock_error)
+
+    exc_info: pytest.ExceptionInfo[ValueError]
+    with pytest.raises(ValueError) as exc_info, lock:
+        raise body_error
+
+    assert exc_info.value is body_error
+    assert exc_info.value.__context__ is unlock_error
+
+
+def test_strict_context_preserves_body_when_notes_are_invalid(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    events: list[str] = []
+    body_error: ValueError = ValueError('body failed')
+    body_error.__dict__['__notes__'] = 'invalid'
+    unlock_error: OSError = OSError('unlock failed')
+    handle: ReleaseHandle = ReleaseHandle(events)
+    lock: utils.Lock = make_lock(handle, raise_on_release_error=True)
+    set_unlock(monkeypatch, events, unlock_error)
+
+    exc_info: pytest.ExceptionInfo[ValueError]
+    with pytest.raises(ValueError) as exc_info, lock:
+        raise body_error
+
+    assert exc_info.value is body_error
+    assert exc_info.value.__context__ is unlock_error
+
+
+def test_repeated_release_is_noop_after_success(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    events: list[str] = []
+    handle: ReleaseHandle = ReleaseHandle(events)
+    lock: utils.Lock = make_lock(handle, raise_on_release_error=True)
+    set_unlock(monkeypatch, events)
+
+    lock.release()
+    lock.release()
+
+    assert events == ['unlock', 'close']
+
+
+def test_repeated_release_is_noop_after_strict_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    events: list[str] = []
+    unlock_error: OSError = OSError('unlock failed')
+    handle: ReleaseHandle = ReleaseHandle(events)
+    lock: utils.Lock = make_lock(handle, raise_on_release_error=True)
+    set_unlock(monkeypatch, events, unlock_error)
+
+    exc_info: pytest.ExceptionInfo[OSError]
+    with pytest.raises(OSError) as exc_info:
+        lock.release()
+    lock.release()
+
+    assert exc_info.value is unlock_error
+    assert events == ['unlock', 'close']
+
+
+def test_strict_context_retains_unlock_and_close_errors(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    events: list[str] = []
+    body_error: ValueError = ValueError('body failed')
+    unlock_error: OSError = OSError('unlock failed')
+    close_error: OSError = OSError('close failed')
+    handle: ReleaseHandle = ReleaseHandle(events, close_error)
+    lock: utils.Lock = make_lock(handle, raise_on_release_error=True)
+    set_unlock(monkeypatch, events, unlock_error)
+
+    exc_info: pytest.ExceptionInfo[ValueError]
+    with pytest.raises(ValueError) as exc_info, lock:
+        raise body_error
+
+    assert exc_info.value is body_error
+    assert exc_info.value.__context__ is unlock_error
+    assert unlock_error.__cause__ is close_error
     assert events == ['unlock', 'close']


### PR DESCRIPTION
## Summary

- add keyword-only `raise_on_release_error=False` to `Lock`
- preserve the PyPI 3.3.0 best-effort default while allowing strict callers to observe unlock and close failures
- preserve protected-body exceptions and retain cleanup failures as context, including Python 3.10 fallback behavior
- add fault-injection coverage for unlock-only, close-only, dual failures, diagnostic failures, context-manager unwinding, and repeated release

## Why

`Lock.release()` suppressed failures from both `portalocker.unlock()` and the file handle's `close()`, so callers could not distinguish successful cleanup from an uncertain release. Raising unconditionally would break current PyPI behavior, so strict reporting is explicit and opt-in.

Closes #117.

## User impact

Existing callers see no behavior change. Callers that require observable cleanup failures can construct `Lock(..., raise_on_release_error=True)`.

## Validation

- `uv run pytest`
- `uv run tox -p auto` (15 environments: CPython 3.10-3.14, PyPy 3.10-3.11, Ruff, mypy, basedpyright, pyrefly, ty, codespell, repo-review, docs)
