### PR TITLE
Add fail-closed PidFileLock contexts

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,10 +11,10 @@
    bare ``OSError`` text to a 2-tuple repr
  * ``LockBase`` is now generic over the acquire return type (typing-only
    change; downstream ``Lock`` subclasses are unaffected)
-* Added ``PidFileLock`` for pidfile-based locking (#106)
-* Added ``PidFileLock.fail_closed()`` for ownership-only contexts; contention
-  raises ``AlreadyLocked`` before entering the body and exposes the competing
-  PID through ``AlreadyLocked.holder_pid`` when readable (#118)
+ * Added ``PidFileLock`` for pidfile-based locking (#106)
+ * Added ``PidFileLock.fail_closed()`` for ownership-only contexts; contention
+   raises ``AlreadyLocked`` before entering the body and exposes the competing
+   PID through ``AlreadyLocked.holder_pid`` when readable (#118)
  * Packaging switched to the ``uv_build`` backend; releases are published to
    PyPI through GitHub Actions Trusted Publishing
  * ``python -m portalocker combine``: ``--output-file`` now opens lazily;

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,7 +11,10 @@
    bare ``OSError`` text to a 2-tuple repr
  * ``LockBase`` is now generic over the acquire return type (typing-only
    change; downstream ``Lock`` subclasses are unaffected)
- * Added ``PidFileLock`` for pidfile-based locking (#106)
+* Added ``PidFileLock`` for pidfile-based locking (#106)
+* Added ``PidFileLock.fail_closed()`` for ownership-only contexts; contention
+  raises ``AlreadyLocked`` before entering the body and exposes the competing
+  PID through ``AlreadyLocked.holder_pid`` when readable (#118)
  * Packaging switched to the ``uv_build`` backend; releases are published to
    PyPI through GitHub Actions Trusted Publishing
  * ``python -m portalocker combine``: ``--output-file`` now opens lazily;
@@ -122,4 +125,3 @@ https://github.com/WoLpH/portalocker/commits/master
 0.1:
 
  * Initial release
-

--- a/README.rst
+++ b/README.rst
@@ -49,6 +49,31 @@ To report a security vulnerability, please use the
 `Tidelift security contact <https://tidelift.com/security>`_.
 Tidelift will coordinate the fix and disclosure.
 
+PidFileLock contexts
+--------------------
+
+The default context is inspection-oriented: it enters even when another
+process owns the lock and returns that process's PID. A ``None`` value means
+this process acquired the lock:
+
+.. code-block:: python
+
+    with portalocker.PidFileLock('worker.pid') as holder_pid:
+        if holder_pid is None:
+            run_singleton_worker()
+        else:
+            print(f'worker already running as PID {holder_pid}')
+
+Use ``fail_closed()`` when the protected body must only run after acquisition:
+
+.. code-block:: python
+
+    try:
+        with portalocker.PidFileLock('worker.pid').fail_closed():
+            run_singleton_worker()
+    except portalocker.AlreadyLocked as exc:
+        print(f'worker already running as PID {exc.holder_pid}')
+
 Redis Locks
 -----------
 
@@ -200,4 +225,3 @@ License
 -------
 
 See the `LICENSE <https://github.com/WoLpH/portalocker/blob/develop/LICENSE>`_ file.
-

--- a/README.rst
+++ b/README.rst
@@ -58,6 +58,8 @@ this process acquired the lock:
 
 .. code-block:: python
 
+    import portalocker
+
     with portalocker.PidFileLock('worker.pid') as holder_pid:
         if holder_pid is None:
             run_singleton_worker()
@@ -67,6 +69,8 @@ this process acquired the lock:
 Use ``fail_closed()`` when the protected body must only run after acquisition:
 
 .. code-block:: python
+
+    import portalocker
 
     try:
         with portalocker.PidFileLock('worker.pid').fail_closed():

--- a/docs/superpowers/plans/2026-07-16-pidfilelock-fail-closed.md
+++ b/docs/superpowers/plans/2026-07-16-pidfilelock-fail-closed.md
@@ -1,0 +1,360 @@
+# PidFileLock Fail-Closed Context Implementation Plan
+
+**For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add an opt-in `PidFileLock.fail_closed()` context that enters only after ownership and reports a competing PID on `AlreadyLocked`.
+
+**Architecture:** Keep the existing inspection context untouched. `PidFileLock.fail_closed()` returns a private `AbstractContextManager[None]` adapter that delegates acquisition and release to the existing lock. `AlreadyLocked` carries an optional `holder_pid` populated by the adapter when contention occurs.
+
+**Tech Stack:** Python 3.10+, `contextlib`, pytest, mypy, tox, Sphinx
+
+---
+
+### Task 1: Successful fail-closed context and static context types
+
+**Files:**
+- Modify: `portalocker_tests/test_pidfilelock.py`
+- Modify: `portalocker/utils.py:695-734`
+
+- [ ] **Step 1: Write the failing runtime and static type tests**
+
+Add `contextlib` to the test imports, then add this static type contract and runtime test after the existing context-manager tests:
+
+```python
+def _pidfilelock_context_types(
+    lock: utils.PidFileLock,
+) -> tuple[
+    contextlib.AbstractContextManager[int | None],
+    contextlib.AbstractContextManager[None],
+]:
+    return lock, lock.fail_closed()
+
+
+def test_pidfilelock_fail_closed_context_manager_success(
+    tmp_path: Path,
+) -> None:
+    pid_file: Path = tmp_path / 'fail_closed_success.pid'
+    lock: utils.PidFileLock = utils.PidFileLock(str(pid_file))
+
+    with lock.fail_closed():
+        assert lock._acquired_lock
+        assert lock.read_pid() == os.getpid()
+
+    assert not lock._acquired_lock
+    assert not pid_file.exists()
+    assert not Path(f'{pid_file}.lock').exists()
+```
+
+- [ ] **Step 2: Run the tests and type checker to verify RED**
+
+Run:
+
+```bash
+uv run pytest portalocker_tests/test_pidfilelock.py::test_pidfilelock_fail_closed_context_manager_success -q --no-cov
+uv run mypy portalocker portalocker_tests
+```
+
+Expected: pytest fails with `AttributeError: 'PidFileLock' object has no attribute 'fail_closed'`; mypy reports the same missing attribute.
+
+- [ ] **Step 3: Implement the minimal successful adapter**
+
+Add this factory to `PidFileLock` after `read_pid()`:
+
+```python
+    def fail_closed(self) -> contextlib.AbstractContextManager[None]:
+        """Return a context that enters only after acquiring this lock."""
+        return _PidFileLockFailClosedContext(self)
+```
+
+Add the private adapter immediately after `PidFileLock`:
+
+```python
+class _PidFileLockFailClosedContext(
+    contextlib.AbstractContextManager[None],
+):
+    """Fail-closed context adapter for :class:`PidFileLock`."""
+
+    def __init__(self, lock: PidFileLock) -> None:
+        self._lock: PidFileLock = lock
+
+    def __enter__(self) -> None:
+        self._lock.acquire()
+        return None
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_value: BaseException | None,
+        traceback: typing.Any,
+    ) -> bool | None:
+        return self._lock.__exit__(exc_type, exc_value, traceback)
+```
+
+- [ ] **Step 4: Run the focused test and type checker to verify GREEN**
+
+Run:
+
+```bash
+uv run pytest portalocker_tests/test_pidfilelock.py::test_pidfilelock_fail_closed_context_manager_success -q --no-cov
+uv run mypy portalocker portalocker_tests
+```
+
+Expected: the focused test passes and mypy exits 0.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add portalocker/utils.py portalocker_tests/test_pidfilelock.py
+git commit -m "add fail-closed pidfile lock context"
+```
+
+### Task 2: Structured holder PID with unavailable PID content
+
+**Files:**
+- Modify: `portalocker_tests/test_pidfilelock.py`
+- Modify: `portalocker/exceptions.py:31-32`
+
+- [ ] **Step 1: Write the failing unavailable-PID test**
+
+```python
+def test_pidfilelock_fail_closed_missing_holder_pid(
+    tmp_path: Path,
+) -> None:
+    pid_file: Path = tmp_path / 'fail_closed_missing_pid.pid'
+    holder: utils.PidFileLock = utils.PidFileLock(str(pid_file))
+    holder.acquire()
+    pid_file.unlink()
+
+    body_entered: bool = False
+    try:
+        contender: utils.PidFileLock = utils.PidFileLock(str(pid_file))
+        exc_info: pytest.ExceptionInfo[portalocker.AlreadyLocked]
+        with pytest.raises(portalocker.AlreadyLocked) as exc_info:
+            with contender.fail_closed():
+                body_entered = True
+
+        assert not body_entered
+        assert exc_info.value.holder_pid is None
+    finally:
+        holder.release()
+```
+
+- [ ] **Step 2: Run the test to verify RED**
+
+Run:
+
+```bash
+uv run pytest portalocker_tests/test_pidfilelock.py::test_pidfilelock_fail_closed_missing_holder_pid -q --no-cov
+```
+
+Expected: fails because `AlreadyLocked` has no `holder_pid` attribute.
+
+- [ ] **Step 3: Add the backward-compatible exception attribute**
+
+Replace the empty `AlreadyLocked` class with:
+
+```python
+class AlreadyLocked(LockException):
+    holder_pid: int | None
+
+    def __init__(
+        self,
+        *args: typing.Any,
+        holder_pid: int | None = None,
+        **kwargs: typing.Any,
+    ) -> None:
+        super().__init__(*args, **kwargs)
+        self.holder_pid = holder_pid
+```
+
+- [ ] **Step 4: Run the focused test to verify GREEN**
+
+Run:
+
+```bash
+uv run pytest portalocker_tests/test_pidfilelock.py::test_pidfilelock_fail_closed_missing_holder_pid -q --no-cov
+```
+
+Expected: passes; the body remains unexecuted and `holder_pid` is `None`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add portalocker/exceptions.py portalocker_tests/test_pidfilelock.py
+git commit -m "add holder pid to already locked errors"
+```
+
+### Task 3: Populate the competing PID on fail-closed contention
+
+**Files:**
+- Modify: `portalocker_tests/test_pidfilelock.py`
+- Modify: `portalocker/utils.py`
+
+- [ ] **Step 1: Write the failing readable-PID contention test**
+
+```python
+def test_pidfilelock_fail_closed_reports_holder_pid(
+    tmp_path: Path,
+) -> None:
+    pid_file: Path = tmp_path / 'fail_closed_holder_pid.pid'
+    holder: utils.PidFileLock = utils.PidFileLock(str(pid_file))
+    holder.acquire()
+
+    body_entered: bool = False
+    try:
+        contender: utils.PidFileLock = utils.PidFileLock(str(pid_file))
+        exc_info: pytest.ExceptionInfo[portalocker.AlreadyLocked]
+        with pytest.raises(portalocker.AlreadyLocked) as exc_info:
+            with contender.fail_closed():
+                body_entered = True
+
+        assert not body_entered
+        assert exc_info.value.holder_pid == os.getpid()
+    finally:
+        holder.release()
+```
+
+- [ ] **Step 2: Run the test to verify RED**
+
+Run:
+
+```bash
+uv run pytest portalocker_tests/test_pidfilelock.py::test_pidfilelock_fail_closed_reports_holder_pid -q --no-cov
+```
+
+Expected: fails because `holder_pid` remains `None`.
+
+- [ ] **Step 3: Enrich and re-raise the same contention exception**
+
+Replace the adapter's `__enter__` body with:
+
+```python
+    def __enter__(self) -> None:
+        try:
+            self._lock.acquire()
+        except exceptions.AlreadyLocked as exc:
+            exc.holder_pid = self._lock.read_pid()
+            raise
+        return None
+```
+
+- [ ] **Step 4: Run all fail-closed tests to verify GREEN**
+
+Run:
+
+```bash
+uv run pytest portalocker_tests/test_pidfilelock.py -q --no-cov
+```
+
+Expected: all `PidFileLock` tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add portalocker/utils.py portalocker_tests/test_pidfilelock.py
+git commit -m "report holder pid on fail-closed contention"
+```
+
+### Task 4: Document inspection and fail-closed contexts
+
+**Files:**
+- Modify: `README.rst`
+- Modify: `CHANGELOG.rst`
+
+- [ ] **Step 1: Add the README examples**
+
+Add a `PidFileLock contexts` section before `Redis Locks` showing both APIs:
+
+```rst
+PidFileLock contexts
+--------------------
+
+The default context is inspection-oriented: it enters even when another
+process owns the lock and returns that process's PID. A ``None`` value means
+this process acquired the lock:
+
+.. code-block:: python
+
+    with portalocker.PidFileLock('worker.pid') as holder_pid:
+        if holder_pid is None:
+            run_singleton_worker()
+        else:
+            print(f'worker already running as PID {holder_pid}')
+
+Use ``fail_closed()`` when the protected body must only run after acquisition:
+
+.. code-block:: python
+
+    try:
+        with portalocker.PidFileLock('worker.pid').fail_closed():
+            run_singleton_worker()
+    except portalocker.AlreadyLocked as exc:
+        print(f'worker already running as PID {exc.holder_pid}')
+```
+
+- [ ] **Step 2: Add the changelog entry**
+
+Add this bullet in the 4.0.0 section after the existing `PidFileLock` addition:
+
+```rst
+* Added ``PidFileLock.fail_closed()`` for ownership-only contexts; contention
+  raises ``AlreadyLocked`` before entering the body and exposes the competing
+  PID through ``AlreadyLocked.holder_pid`` when readable (#118)
+```
+
+- [ ] **Step 3: Build the documentation**
+
+Run:
+
+```bash
+uv run tox -e docs
+```
+
+Expected: Sphinx exits 0 with warnings treated as errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add README.rst CHANGELOG.rst
+git commit -m "document fail-closed pidfile locks"
+```
+
+### Task 5: Full verification and diff audit
+
+**Files:**
+- Verify: all changed files
+
+- [ ] **Step 1: Run the complete test suite**
+
+```bash
+uv run pytest
+```
+
+Expected: all tests pass with 100% branch coverage.
+
+- [ ] **Step 2: Run lint, static analysis, metadata, spelling, and docs checks**
+
+```bash
+uv run tox -e ruff,mypy,basedpyright,pyrefly,ty,codespell,repo-review,docs
+```
+
+Expected: every tox environment exits 0.
+
+- [ ] **Step 3: Build both distributions**
+
+```bash
+uv build
+```
+
+Expected: source distribution and wheel build successfully.
+
+- [ ] **Step 4: Audit the final branch**
+
+```bash
+git diff --check feature/modernize-4.0.0...HEAD
+git status --short --branch
+git log --oneline feature/modernize-4.0.0..HEAD
+```
+
+Expected: no whitespace errors, no uncommitted files, and only the design,
+implementation, tests, and documentation commits for #118.

--- a/docs/superpowers/specs/2026-07-15-pidfilelock-fail-closed-design.md
+++ b/docs/superpowers/specs/2026-07-15-pidfilelock-fail-closed-design.md
@@ -1,0 +1,82 @@
+# PidFileLock Fail-Closed Context Design
+
+## Goal
+
+Add an opt-in `PidFileLock` context-manager API that never executes the
+protected body unless this process owns the lock, while preserving the current
+inspection-oriented context behavior.
+
+## Existing Behavior
+
+`with PidFileLock(...) as holder_pid:` remains unchanged:
+
+- `holder_pid is None` means this process acquired the lock.
+- An integer means another process holds the lock, but the context body still
+  runs so callers can inspect the holder.
+
+This behavior remains the default for compatibility.
+
+## Public API
+
+`PidFileLock.fail_closed()` returns a context manager whose `__enter__` return
+type is `None`:
+
+```python
+lock = portalocker.PidFileLock('worker.pid')
+
+with lock.fail_closed():
+    run_singleton_worker()
+```
+
+Entering this context calls the existing `PidFileLock.acquire()` path. The body
+runs only after acquisition succeeds. Context exit delegates to the lock's
+existing release behavior.
+
+The existing context remains typed as `int | None`; the fail-closed context is
+typed as `AbstractContextManager[None]`. This distinguishes inspection and
+ownership contexts without making `PidFileLock` generic or adding a public
+subclass.
+
+## Contention and Error Data
+
+`AlreadyLocked` gains a backward-compatible, optional
+`holder_pid: int | None` attribute. Existing construction and exception
+handling continue to work unchanged.
+
+When fail-closed entry catches `AlreadyLocked`, it reads the PID file and stores
+the result in `holder_pid` before re-raising the same exception. Missing,
+unreadable, empty, or invalid PID files produce `holder_pid is None`. Other
+acquisition errors propagate unchanged.
+
+The adapter does not suppress exceptions from the protected body. It releases
+the lock through the existing `PidFileLock.__exit__` path only after successful
+entry.
+
+## Implementation Boundaries
+
+- `PidFileLock` owns acquisition, PID reading, release, and the public
+  `fail_closed()` factory method.
+- A private context-manager adapter owns only fail-closed entry and exit
+  semantics.
+- `AlreadyLocked` owns the structured holder PID attribute.
+- No constructor flags, public subclasses, retry behavior, or PID liveness
+  checks are added.
+
+## Testing
+
+Tests will verify:
+
+- Existing inspection contexts still enter and return the competing PID.
+- A fail-closed context acquires, enters, and cleans up normally.
+- A contended fail-closed context raises before its body executes.
+- The raised `AlreadyLocked` exposes the competing PID when readable.
+- Invalid or unavailable PID content produces `holder_pid is None`.
+- Static type checks retain `int | None` for inspection contexts and infer
+  `None` for fail-closed contexts.
+- The complete test and type-check suites remain clean.
+
+## Documentation
+
+The README will show inspection and fail-closed examples side by side. The
+4.0.0 changelog will record the new opt-in behavior and structured exception
+attribute.

--- a/portalocker/exceptions.py
+++ b/portalocker/exceptions.py
@@ -29,8 +29,6 @@ class LockException(BaseLockException):
 
 
 class AlreadyLocked(LockException):
-    holder_pid: int | None
-
     def __init__(
         self,
         *args: typing.Any,

--- a/portalocker/exceptions.py
+++ b/portalocker/exceptions.py
@@ -29,7 +29,16 @@ class LockException(BaseLockException):
 
 
 class AlreadyLocked(LockException):
-    pass
+    holder_pid: int | None
+
+    def __init__(
+        self,
+        *args: typing.Any,
+        holder_pid: int | None = None,
+        **kwargs: typing.Any,
+    ) -> None:
+        super().__init__(*args, **kwargs)
+        self.holder_pid: int | None = holder_pid
 
 
 class FileToLarge(LockException):

--- a/portalocker/exceptions.py
+++ b/portalocker/exceptions.py
@@ -29,6 +29,8 @@ class LockException(BaseLockException):
 
 
 class AlreadyLocked(LockException):
+    holder_pid: int | None = None
+
     def __init__(
         self,
         *args: typing.Any,
@@ -36,7 +38,7 @@ class AlreadyLocked(LockException):
         **kwargs: typing.Any,
     ) -> None:
         super().__init__(*args, **kwargs)
-        self.holder_pid: int | None = holder_pid
+        self.holder_pid = holder_pid
 
 
 class FileToLarge(LockException):

--- a/portalocker/utils.py
+++ b/portalocker/utils.py
@@ -791,7 +791,11 @@ class _PidFileLockFailClosedContext(
         self._lock: PidFileLock = lock
 
     def __enter__(self) -> None:
-        self._lock.acquire()
+        try:
+            self._lock.acquire()
+        except exceptions.AlreadyLocked as exc:
+            exc.holder_pid = self._lock.read_pid()
+            raise
         return None
 
     def __exit__(

--- a/portalocker/utils.py
+++ b/portalocker/utils.py
@@ -706,6 +706,10 @@ class PidFileLock(TemporaryFileLock):
 
     # `PidFileLock` deliberately breaks the `Lock.__enter__` contract: it
     # reports the competing PID instead of returning a filehandle.
+    def fail_closed(self) -> contextlib.AbstractContextManager[None]:
+        """Return a context that enters only after acquiring this lock."""
+        return _PidFileLockFailClosedContext(self)
+
     def __enter__(self) -> int | None:  # type: ignore[override]  # ty: ignore[invalid-method-override]
         """
         Context manager entry that returns:
@@ -776,6 +780,27 @@ class PidFileLock(TemporaryFileLock):
                 self._inner_lock = None
                 with contextlib.suppress(Exception):
                     inner_lock.release()
+
+
+class _PidFileLockFailClosedContext(
+    contextlib.AbstractContextManager[None],
+):
+    """Fail-closed context adapter for :class:`PidFileLock`."""
+
+    def __init__(self, lock: PidFileLock) -> None:
+        self._lock: PidFileLock = lock
+
+    def __enter__(self) -> None:
+        self._lock.acquire()
+        return None
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_value: BaseException | None,
+        traceback: typing.Any,
+    ) -> bool | None:
+        return self._lock.__exit__(exc_type, exc_value, traceback)
 
 
 class BoundedSemaphore(LockBase['Lock | None']):

--- a/portalocker/utils.py
+++ b/portalocker/utils.py
@@ -704,12 +704,16 @@ class PidFileLock(TemporaryFileLock):
             pass
         return None
 
-    # `PidFileLock` deliberately breaks the `Lock.__enter__` contract: it
-    # reports the competing PID instead of returning a filehandle.
     def fail_closed(self) -> contextlib.AbstractContextManager[None]:
-        """Return a context that enters only after acquiring this lock."""
+        """Return a context that enters only after acquiring this lock.
+
+        :raises AlreadyLocked: if another process holds the lock. Its
+            ``holder_pid`` attribute contains the competing PID when readable.
+        """
         return _PidFileLockFailClosedContext(self)
 
+    # `PidFileLock` deliberately breaks the `Lock.__enter__` contract: it
+    # reports the competing PID instead of returning a filehandle.
     def __enter__(self) -> int | None:  # type: ignore[override]  # ty: ignore[invalid-method-override]
         """
         Context manager entry that returns:

--- a/portalocker/utils.py
+++ b/portalocker/utils.py
@@ -796,7 +796,6 @@ class _PidFileLockFailClosedContext(
         except exceptions.AlreadyLocked as exc:
             exc.holder_pid = self._lock.read_pid()
             raise
-        return None
 
     def __exit__(
         self,

--- a/portalocker_tests/test_pidfilelock.py
+++ b/portalocker_tests/test_pidfilelock.py
@@ -116,6 +116,27 @@ def test_pidfilelock_fail_closed_missing_holder_pid(
         holder.release()
 
 
+def test_pidfilelock_fail_closed_reports_holder_pid(
+    tmp_path: Path,
+) -> None:
+    pid_file: Path = tmp_path / 'fail_closed_holder_pid.pid'
+    holder: utils.PidFileLock = utils.PidFileLock(str(pid_file))
+    holder.acquire()
+
+    body_entered: bool = False
+    try:
+        contender: utils.PidFileLock = utils.PidFileLock(str(pid_file))
+        exc_info: pytest.ExceptionInfo[portalocker.AlreadyLocked]
+        with pytest.raises(portalocker.AlreadyLocked) as exc_info:
+            with contender.fail_closed():
+                body_entered = True
+
+        assert not body_entered
+        assert exc_info.value.holder_pid == os.getpid()
+    finally:
+        holder.release()
+
+
 def test_pidfilelock_context_manager_already_locked():
     """Test context manager when another process holds the lock."""
     with tempfile.TemporaryDirectory() as tmpdir:

--- a/portalocker_tests/test_pidfilelock.py
+++ b/portalocker_tests/test_pidfilelock.py
@@ -106,9 +106,11 @@ def test_pidfilelock_fail_closed_missing_holder_pid(
     try:
         contender: utils.PidFileLock = utils.PidFileLock(str(pid_file))
         exc_info: pytest.ExceptionInfo[portalocker.AlreadyLocked]
-        with pytest.raises(portalocker.AlreadyLocked) as exc_info:
-            with contender.fail_closed():
-                body_entered = True
+        with (
+            pytest.raises(portalocker.AlreadyLocked) as exc_info,
+            contender.fail_closed(),
+        ):
+            body_entered = True
 
         assert not body_entered
         assert exc_info.value.holder_pid is None
@@ -127,9 +129,11 @@ def test_pidfilelock_fail_closed_reports_holder_pid(
     try:
         contender: utils.PidFileLock = utils.PidFileLock(str(pid_file))
         exc_info: pytest.ExceptionInfo[portalocker.AlreadyLocked]
-        with pytest.raises(portalocker.AlreadyLocked) as exc_info:
-            with contender.fail_closed():
-                body_entered = True
+        with (
+            pytest.raises(portalocker.AlreadyLocked) as exc_info,
+            contender.fail_closed(),
+        ):
+            body_entered = True
 
         assert not body_entered
         assert exc_info.value.holder_pid == os.getpid()

--- a/portalocker_tests/test_pidfilelock.py
+++ b/portalocker_tests/test_pidfilelock.py
@@ -24,6 +24,14 @@ def _pidfilelock_context_types(
     return lock, lock.fail_closed()
 
 
+def test_already_locked_holder_pid_exists_without_init() -> None:
+    exc: portalocker.AlreadyLocked = portalocker.AlreadyLocked.__new__(
+        portalocker.AlreadyLocked,
+    )
+
+    assert exc.holder_pid is None
+
+
 def test_pidfilelock_creation():
     """Test basic PidFileLock creation."""
     with tempfile.TemporaryDirectory() as tmpdir:

--- a/portalocker_tests/test_pidfilelock.py
+++ b/portalocker_tests/test_pidfilelock.py
@@ -1,6 +1,7 @@
 """Tests for PidFileLock class."""
 
 import builtins
+import contextlib
 import multiprocessing
 import os
 import tempfile
@@ -12,6 +13,15 @@ import pytest
 
 import portalocker
 from portalocker import utils
+
+
+def _pidfilelock_context_types(
+    lock: utils.PidFileLock,
+) -> tuple[
+    contextlib.AbstractContextManager[int | None],
+    contextlib.AbstractContextManager[None],
+]:
+    return lock, lock.fail_closed()
 
 
 def test_pidfilelock_creation():
@@ -65,6 +75,23 @@ def test_pidfilelock_context_manager_success():
 
         assert lock_released
         assert file_cleaned
+
+
+def test_pidfilelock_fail_closed_context_manager_success(
+    tmp_path: Path,
+) -> None:
+    pid_file: Path = tmp_path / 'fail_closed_success.pid'
+    lock: utils.PidFileLock = utils.PidFileLock(str(pid_file))
+
+    with lock.fail_closed():
+        is_acquired: bool = lock._acquired_lock
+        assert is_acquired
+        assert lock.read_pid() == os.getpid()
+
+    is_released: bool = not lock._acquired_lock
+    assert is_released
+    assert not pid_file.exists()
+    assert not Path(f'{pid_file}.lock').exists()
 
 
 def test_pidfilelock_context_manager_already_locked():

--- a/portalocker_tests/test_pidfilelock.py
+++ b/portalocker_tests/test_pidfilelock.py
@@ -94,6 +94,28 @@ def test_pidfilelock_fail_closed_context_manager_success(
     assert not Path(f'{pid_file}.lock').exists()
 
 
+def test_pidfilelock_fail_closed_missing_holder_pid(
+    tmp_path: Path,
+) -> None:
+    pid_file: Path = tmp_path / 'fail_closed_missing_pid.pid'
+    holder: utils.PidFileLock = utils.PidFileLock(str(pid_file))
+    holder.acquire()
+    pid_file.unlink()
+
+    body_entered: bool = False
+    try:
+        contender: utils.PidFileLock = utils.PidFileLock(str(pid_file))
+        exc_info: pytest.ExceptionInfo[portalocker.AlreadyLocked]
+        with pytest.raises(portalocker.AlreadyLocked) as exc_info:
+            with contender.fail_closed():
+                body_entered = True
+
+        assert not body_entered
+        assert exc_info.value.holder_pid is None
+    finally:
+        holder.release()
+
+
 def test_pidfilelock_context_manager_already_locked():
     """Test context manager when another process holds the lock."""
     with tempfile.TemporaryDirectory() as tmpdir:


### PR DESCRIPTION
## Summary

- add opt-in `PidFileLock.fail_closed()` contexts that never enter without lock ownership
- expose a readable competing PID through `AlreadyLocked.holder_pid`
- preserve the existing inspection context and document both APIs

## Why

`PidFileLock` currently enters its context body even when another process owns the lock. That behavior remains useful for inspection, but it is unsafe for callers that expect a context manager to guarantee ownership. The new adapter provides an explicit fail-closed path without breaking existing callers.

## User impact

Existing `with PidFileLock(...) as holder_pid:` behavior is unchanged. Callers that require ownership can use `with PidFileLock(...).fail_closed():`; contention raises `AlreadyLocked` before the body executes.

## Validation

- `uv run pytest` — 116 passed, 17 skipped, 100% coverage
- `uv run tox -e ruff,mypy,basedpyright,pyrefly,ty,codespell,repo-review,docs -q`
- `uv build`

Closes #118