### PR TITLE
Add shared RedisLock support

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -33,6 +33,10 @@
    ``fail_when_locked=True`` fails fast instead of polling the full timeout,
    internally-created connections are closed on release, and a failed
    ``acquire()`` rolls back cleanly so the lock can be retried
+ * Added shared ``RedisLock`` readers through ``LockFlags.SHARED``. Waiting
+   writers gate new readers to prevent starvation, holder-specific heartbeats
+   preserve stale-client cleanup, and legacy Redis lock responses are treated
+   as exclusive for mixed-version safety (#124)
  * Fixed ``FlockLocker``/``LockfLocker`` on POSIX to use their named syscall
    (previously silently used the global ``LOCKER``); the module-level
    ``lock()``/``unlock()`` on POSIX now accept all documented ``LOCKER``
@@ -122,4 +126,3 @@ https://github.com/WoLpH/portalocker/commits/master
 0.1:
 
  * Initial release
-

--- a/README.rst
+++ b/README.rst
@@ -81,8 +81,37 @@ Usage is really easy:
     with lock:
         print('do something here')
 
+Shared locks allow multiple readers while remaining mutually exclusive with
+writers:
+
+::
+
+    read_lock = portalocker.RedisLock(
+        'some_lock_channel_name',
+        flags=portalocker.LockFlags.SHARED,
+    )
+
+    with read_lock:
+        print('read shared state')
+
+Waiting writers prevent new readers from entering, so a continuous stream of
+readers cannot starve an exclusive lock. New shared locks also interoperate with
+older portalocker clients: legacy Redis locks are treated as exclusive.
+
 The API is essentially identical to the other ``Lock`` classes so in addition
 to the ``with`` statement you can also use ``lock.acquire(...)``.
+
+The normal test suite uses ``fakeredis``. To optionally repeat the Redis tests
+against a locally running server:
+
+::
+
+    redis-server
+    tox -e redis-live
+
+Set ``REDIS_HOST`` or ``REDIS_PORT`` when the server does not use
+``localhost:6379``. The ``redis-live`` environment fails instead of skipping
+when it cannot connect.
 
 Python 2
 --------
@@ -200,4 +229,3 @@ License
 -------
 
 See the `LICENSE <https://github.com/WoLpH/portalocker/blob/develop/LICENSE>`_ file.
-

--- a/portalocker/redis.py
+++ b/portalocker/redis.py
@@ -247,9 +247,13 @@ class RedisLock(utils.LockBase['RedisLock']):
             )
             pubsub.parse_response()  # type: ignore[no-untyped-call]
             pubsub.subscribe(**{self.channel: self.channel_handler})
+            # A daemon thread so an unreleased lock can never block
+            # interpreter exit; losing the connection releases the lock by
+            # design, which is exactly what process exit should do.
             self.thread = PubSubWorkerThread(
                 pubsub,
                 sleep_time=self.thread_sleep_time,
+                daemon=True,
             )
             self.thread.start()
             time.sleep(0.01)
@@ -300,8 +304,7 @@ class RedisLock(utils.LockBase['RedisLock']):
         for client_ in clients:
             client_name: str = client_.get('name', '')
             unavailable: bool = (
-                client_name == self.legacy_client_name
-                and not legacy_responded
+                client_name == self.legacy_client_name and not legacy_responded
             ) or (
                 client_name.startswith(client_name_prefix)
                 and client_name.removeprefix(client_name_prefix)
@@ -389,9 +392,7 @@ class RedisLock(utils.LockBase['RedisLock']):
         self,
         holders: list[RedisLockHolder],
     ) -> bool:
-        if any(
-            holder.mode is RedisLockMode.EXCLUSIVE for holder in holders
-        ):
+        if any(holder.mode is RedisLockMode.EXCLUSIVE for holder in holders):
             return False
         pending_holder_ids: list[str] = sorted(
             holder.holder_id
@@ -399,8 +400,7 @@ class RedisLock(utils.LockBase['RedisLock']):
             if holder.mode is RedisLockMode.PENDING
         )
         return bool(
-            pending_holder_ids
-            and pending_holder_ids[0] == self.holder_id
+            pending_holder_ids and pending_holder_ids[0] == self.holder_id
         )
 
     def _resolve_lock_holders(
@@ -422,8 +422,7 @@ class RedisLock(utils.LockBase['RedisLock']):
                 self.release()
                 raise exceptions.AlreadyLocked()
             if holders is not None and not any(
-                holder.mode is RedisLockMode.SHARED
-                for holder in holders
+                holder.mode is RedisLockMode.SHARED for holder in holders
             ):
                 self.mode = RedisLockMode.EXCLUSIVE
                 return True

--- a/portalocker/redis.py
+++ b/portalocker/redis.py
@@ -5,20 +5,35 @@
 from __future__ import annotations
 
 import _thread
+import enum
 import json
 import logging
 import random
 import time
 import typing
+import uuid
 
 import redis.client
 
-from . import exceptions, utils
+from . import constants, exceptions, utils
 
 logger = logging.getLogger(__name__)
 
 DEFAULT_UNAVAILABLE_TIMEOUT = 1
 DEFAULT_THREAD_SLEEP_TIME = 0.1
+REDIS_LOCK_PROTOCOL_VERSION = 1
+
+
+class RedisLockMode(str, enum.Enum):
+    EXCLUSIVE = 'exclusive'
+    PENDING = 'pending'
+    SHARED = 'shared'
+
+
+class RedisLockHolder(typing.NamedTuple):
+    holder_id: str
+    mode: RedisLockMode
+    legacy: bool = False
 
 
 class PubSubWorkerThread(redis.client.PubSubWorkerThread):
@@ -64,6 +79,10 @@ class RedisLock(utils.LockBase['RedisLock']):
             given. The `DEFAULT_REDIS_KWARGS` are used as default, if you want
             to override these you need to explicitly specify a value (e.g.
             `health_check_interval=0`)
+        flags: `LockFlags.EXCLUSIVE` (the default) or `LockFlags.SHARED`.
+            Shared holders may coexist, while an exclusive holder waits for
+            all shared holders to release. Other flag combinations are
+            rejected; use `fail_when_locked` for non-blocking acquisition.
 
     """
 
@@ -74,6 +93,10 @@ class RedisLock(utils.LockBase['RedisLock']):
     connection: redis.client.Redis | None
     pubsub: redis.client.PubSub | None = None
     close_connection: bool
+    flags: constants.LockFlags
+    holder_id: str
+    mode: RedisLockMode
+    writer_elected: bool
 
     DEFAULT_REDIS_KWARGS: typing.ClassVar[dict[str, typing.Any]] = dict(
         health_check_interval=10,
@@ -90,6 +113,7 @@ class RedisLock(utils.LockBase['RedisLock']):
         thread_sleep_time: float = DEFAULT_THREAD_SLEEP_TIME,
         unavailable_timeout: float = DEFAULT_UNAVAILABLE_TIMEOUT,
         redis_kwargs: dict[str, typing.Any] | None = None,
+        flags: constants.LockFlags = constants.LockFlags.EXCLUSIVE,
     ) -> None:
         # We don't want to close connections given as an argument
         self.close_connection = not connection
@@ -100,6 +124,22 @@ class RedisLock(utils.LockBase['RedisLock']):
         self.thread_sleep_time = thread_sleep_time
         self.unavailable_timeout = unavailable_timeout
         self.redis_kwargs = redis_kwargs or dict()
+        if flags not in (
+            constants.LockFlags.EXCLUSIVE,
+            constants.LockFlags.SHARED,
+        ):
+            raise ValueError(
+                'RedisLock flags must contain exactly one of '
+                'LockFlags.EXCLUSIVE or LockFlags.SHARED'
+            )
+        self.flags = flags
+        self.holder_id = uuid.uuid4().hex
+        self.writer_elected = False
+        self.mode = (
+            RedisLockMode.SHARED
+            if flags == constants.LockFlags.SHARED
+            else RedisLockMode.PENDING
+        )
 
         for key, value in self.DEFAULT_REDIS_KWARGS.items():
             self.redis_kwargs.setdefault(key, value)
@@ -134,21 +174,43 @@ class RedisLock(utils.LockBase['RedisLock']):
         if message.get('type') != 'message':  # pragma: no cover
             return
 
-        raw_data = message.get('data')
+        raw_data: str | None = message.get('data')
         if not raw_data:
             return
 
         try:
-            data = json.loads(raw_data)
-        except TypeError:  # pragma: no cover
-            logger.debug('TypeError while parsing: %r', message)
+            data: typing.Any = json.loads(raw_data)
+        except (json.JSONDecodeError, TypeError):
+            logger.debug('Invalid Redis lock message: %r', message)
+            return
+        if not isinstance(data, dict):
+            return
+        data_dict: dict[str, typing.Any] = typing.cast(
+            'dict[str, typing.Any]',
+            data,
+        )
+        response_channel: typing.Any = data_dict.get('response_channel')
+        if not isinstance(response_channel, str) or not response_channel:
             return
 
         assert self.connection is not None
-        self.connection.publish(data['response_channel'], str(time.time()))
+        self.connection.publish(
+            response_channel,
+            json.dumps(
+                {
+                    'holder_id': self.holder_id,
+                    'mode': self.mode.value,
+                    'protocol': REDIS_LOCK_PROTOCOL_VERSION,
+                }
+            ),
+        )
 
     @property
     def client_name(self) -> str:
+        return f'{self.legacy_client_name}-{self.holder_id}'
+
+    @property
+    def legacy_client_name(self) -> str:
         return f'{self.channel}-lock'
 
     def _timeout_generator(
@@ -171,83 +233,257 @@ class RedisLock(utils.LockBase['RedisLock']):
             time.sleep(sleep_time)
             yield 0
 
+    def _start_subscription(
+        self,
+        connection: redis.client.Redis,
+    ) -> None:
+        pubsub: redis.client.PubSub = self._get_pubsub(connection)
+        self.pubsub = pubsub
+        try:
+            pubsub.execute_command(  # type: ignore[no-untyped-call]
+                'CLIENT',
+                'SETNAME',
+                self.client_name,
+            )
+            pubsub.parse_response()  # type: ignore[no-untyped-call]
+            pubsub.subscribe(**{self.channel: self.channel_handler})
+            self.thread = PubSubWorkerThread(
+                pubsub,
+                sleep_time=self.thread_sleep_time,
+            )
+            self.thread.start()
+            time.sleep(0.01)
+        except Exception:
+            self.release()
+            raise
+
+    def _parse_lock_response(
+        self,
+        raw_data: typing.Any,
+        legacy_index: int,
+    ) -> RedisLockHolder:
+        try:
+            data: typing.Any = json.loads(raw_data)
+            holder_id: typing.Any = data.get('holder_id')
+            mode: typing.Any = data.get('mode')
+            protocol: typing.Any = data.get('protocol')
+            if (
+                protocol == REDIS_LOCK_PROTOCOL_VERSION
+                and isinstance(holder_id, str)
+                and isinstance(mode, str)
+            ):
+                return RedisLockHolder(
+                    holder_id=holder_id,
+                    mode=RedisLockMode(mode),
+                )
+        except (AttributeError, TypeError, ValueError):
+            pass
+
+        return RedisLockHolder(
+            holder_id=f'legacy-{legacy_index}',
+            mode=RedisLockMode.EXCLUSIVE,
+            legacy=True,
+        )
+
+    def _kill_unavailable_locks(
+        self,
+        connection: redis.client.Redis,
+        responding_holders: typing.Iterable[RedisLockHolder],
+    ) -> None:
+        holders: list[RedisLockHolder] = list(responding_holders)
+        responding_holder_ids: set[str] = {
+            holder.holder_id for holder in holders if not holder.legacy
+        }
+        legacy_responded: bool = any(holder.legacy for holder in holders)
+        client_name_prefix: str = f'{self.legacy_client_name}-'
+        clients: list[dict[str, str]] = connection.client_list()
+        for client_ in clients:
+            client_name: str = client_.get('name', '')
+            unavailable: bool = (
+                client_name == self.legacy_client_name
+                and not legacy_responded
+            ) or (
+                client_name.startswith(client_name_prefix)
+                and client_name.removeprefix(client_name_prefix)
+                not in responding_holder_ids
+            )
+            if unavailable:
+                logger.warning(
+                    'Killing unavailable redis client: %r',
+                    client_,
+                )
+                connection.client_kill_filter(client_.get('id'))
+
+    def _collect_lock_holders(
+        self,
+        connection: redis.client.Redis,
+        expected_subscribers: int,
+        timeout: float,
+    ) -> list[RedisLockHolder] | None:
+        response_channel: str = f'{self.channel}-{uuid.uuid4().hex}'
+        check_interval: float = min(self.thread_sleep_time, timeout / 10)
+        pubsub: redis.client.PubSub = self._get_pubsub(connection)
+        holders: dict[str, RedisLockHolder] = {}
+        legacy_index: int = 0
+        try:
+            pubsub.subscribe(response_channel)
+            for _ in self._timeout_generator(timeout, check_interval):
+                confirmation: dict[str, typing.Any] | None = typing.cast(
+                    'dict[str, typing.Any] | None',
+                    pubsub.get_message(timeout=check_interval),
+                )
+                if confirmation and confirmation.get('type') == 'subscribe':
+                    break
+
+            connection.publish(
+                self.channel,
+                json.dumps(
+                    {
+                        'message': 'ping',
+                        'response_channel': response_channel,
+                    }
+                ),
+            )
+
+            for _ in self._timeout_generator(timeout, check_interval):
+                message: dict[str, typing.Any] | None = typing.cast(
+                    'dict[str, typing.Any] | None',
+                    pubsub.get_message(timeout=check_interval),
+                )
+                if message and message.get('type') == 'message':
+                    holder: RedisLockHolder = self._parse_lock_response(
+                        message.get('data'),
+                        legacy_index,
+                    )
+                    holders[holder.holder_id] = holder
+                    legacy_index += int(holder.legacy)
+                    if len(holders) >= expected_subscribers:
+                        break
+
+            current_subscribers: int = self._get_subscriber_count(connection)
+            logger.debug(
+                'Redis lock %s probe expected=%d received=%d current=%d',
+                self.holder_id,
+                expected_subscribers,
+                len(holders),
+                current_subscribers,
+            )
+            if current_subscribers != expected_subscribers:
+                return None
+            if len(holders) < expected_subscribers:
+                self._kill_unavailable_locks(connection, holders.values())
+                return None
+            return list(holders.values())
+        finally:
+            pubsub.close()
+
+    def _holders_are_compatible(
+        self,
+        holders: list[RedisLockHolder],
+    ) -> bool:
+        return self.flags == constants.LockFlags.SHARED and all(
+            holder.mode is RedisLockMode.SHARED for holder in holders
+        )
+
+    def _writer_is_elected(
+        self,
+        holders: list[RedisLockHolder],
+    ) -> bool:
+        if any(
+            holder.mode is RedisLockMode.EXCLUSIVE for holder in holders
+        ):
+            return False
+        pending_holder_ids: list[str] = sorted(
+            holder.holder_id
+            for holder in holders
+            if holder.mode is RedisLockMode.PENDING
+        )
+        return bool(
+            pending_holder_ids
+            and pending_holder_ids[0] == self.holder_id
+        )
+
     def acquire(
         self,
         timeout: float | None = None,
         check_interval: float | None = None,
         fail_when_locked: bool | None = None,
     ) -> RedisLock:
-        timeout = utils.coalesce(timeout, self.timeout, 0.0)
-        check_interval = utils.coalesce(
-            check_interval,
-            self.check_interval,
-            0.0,
+        effective_timeout: float = typing.cast(
+            'float',
+            utils.coalesce(timeout, self.timeout, 0.0),
         )
-        fail_when_locked = utils.coalesce(
-            fail_when_locked,
-            self.fail_when_locked,
+        effective_check_interval: float = typing.cast(
+            'float',
+            utils.coalesce(check_interval, self.check_interval, 0.0),
+        )
+        effective_fail_when_locked: bool = typing.cast(
+            'bool',
+            utils.coalesce(fail_when_locked, self.fail_when_locked, False),
         )
 
         assert not self.pubsub, 'This lock is already active'
-        connection = self.get_connection()
+        if self.flags == constants.LockFlags.EXCLUSIVE:
+            self.mode = RedisLockMode.PENDING
+            self.writer_elected = False
+        connection: redis.client.Redis = self.get_connection()
 
-        timeout_generator = self._timeout_generator(timeout, check_interval)
-        for _ in timeout_generator:  # pragma: no branch
-            subscribers = self._get_subscriber_count(connection)
+        for _ in self._timeout_generator(
+            effective_timeout,
+            effective_check_interval,
+        ):
+            if self.pubsub is None:
+                self._start_subscription(connection)
+            subscribers: int = self._get_subscriber_count(connection)
+            logger.debug(
+                'Redis lock %s mode=%s observed %d subscribers',
+                self.holder_id,
+                self.mode.value,
+                subscribers,
+            )
+            if subscribers == 1:
+                if self.flags == constants.LockFlags.EXCLUSIVE:
+                    self.mode = RedisLockMode.EXCLUSIVE
+                return self
 
-            if subscribers:
-                logger.debug(
-                    'Found %d lock subscribers for %s',
-                    subscribers,
-                    self.channel,
-                )
-
-                if self.check_or_kill_lock(
-                    connection,
-                    self.unavailable_timeout,
+            holders: list[RedisLockHolder] | None = self._collect_lock_holders(
+                connection,
+                subscribers,
+                self.unavailable_timeout,
+            )
+            logger.debug(
+                'Redis lock %s observed holders=%r',
+                self.holder_id,
+                holders,
+            )
+            if holders is not None and self._holders_are_compatible(holders):
+                return self
+            writer_is_elected: bool = (
+                holders is not None
+                and self.flags == constants.LockFlags.EXCLUSIVE
+                and self._writer_is_elected(holders)
+            )
+            if writer_is_elected:
+                self.writer_elected = True
+                if effective_fail_when_locked:
+                    self.release()
+                    raise exceptions.AlreadyLocked()
+                if holders is not None and not any(
+                    holder.mode is RedisLockMode.SHARED
+                    for holder in holders
                 ):
-                    # The holder is alive. When `fail_when_locked` is set we
-                    # must not keep polling until the timeout expires; fail
-                    # immediately as documented.
-                    if fail_when_locked:
-                        raise exceptions.AlreadyLocked()
-                    continue
-                else:  # pragma: no cover
-                    subscribers = 0
-
-            # Note: this should not be changed to an elif because the if
-            # above can still end up here
-            if not subscribers:
-                connection.client_setname(self.client_name)
-                pubsub = self._get_pubsub(connection)
-                self.pubsub = pubsub
-                try:
-                    pubsub.subscribe(**{self.channel: self.channel_handler})
-                    self.thread = PubSubWorkerThread(
-                        pubsub,
-                        sleep_time=self.thread_sleep_time,
-                    )
-                    self.thread.start()
-                    time.sleep(0.01)
-                    subscribers = self._get_subscriber_count(connection)
-                except Exception:
-                    # Roll back so a partially initialised `self.pubsub` /
-                    # `self.thread` cannot brick a retry via the assertion at
-                    # the top of `acquire` (or leak the worker thread).
-                    self.release()
-                    raise
-                if subscribers == 1:  # pragma: no branch
+                    self.mode = RedisLockMode.EXCLUSIVE
                     return self
-                else:  # pragma: no cover
-                    # NOTE: this retry reuses the outer timeout deadline,
-                    # which may already have expired, so a lost race here can
-                    # end the acquire attempt early instead of retrying within
-                    # a fresh window.
-                    self.release()
+                continue
+            if holders is None and self.writer_elected:
+                continue
 
-            if fail_when_locked:  # pragma: no cover
+            self.release()
+            logger.debug('Redis lock %s released to retry', self.holder_id)
+            if effective_fail_when_locked:
                 raise exceptions.AlreadyLocked()
 
+        self.release()
         raise exceptions.AlreadyLocked()
 
     def check_or_kill_lock(
@@ -308,6 +544,7 @@ class RedisLock(utils.LockBase['RedisLock']):
             pubsub.close()
 
     def release(self) -> None:
+        self.writer_elected = False
         if self.thread:  # pragma: no branch
             self.thread.stop()
             self.thread.join()

--- a/portalocker/redis.py
+++ b/portalocker/redis.py
@@ -403,6 +403,40 @@ class RedisLock(utils.LockBase['RedisLock']):
             and pending_holder_ids[0] == self.holder_id
         )
 
+    def _resolve_lock_holders(
+        self,
+        holders: list[RedisLockHolder] | None,
+        fail_when_locked: bool,
+    ) -> bool:
+        if holders is not None and self._holders_are_compatible(holders):
+            return True
+
+        writer_is_elected: bool = (
+            holders is not None
+            and self.flags == constants.LockFlags.EXCLUSIVE
+            and self._writer_is_elected(holders)
+        )
+        if writer_is_elected:
+            self.writer_elected = True
+            if fail_when_locked:
+                self.release()
+                raise exceptions.AlreadyLocked()
+            if holders is not None and not any(
+                holder.mode is RedisLockMode.SHARED for holder in holders
+            ):
+                self.mode = RedisLockMode.EXCLUSIVE
+                return True
+            return False
+
+        if holders is None and self.writer_elected:
+            return False
+
+        self.release()
+        logger.debug('Redis lock %s released to retry', self.holder_id)
+        if fail_when_locked:
+            raise exceptions.AlreadyLocked()
+        return False
+
     def acquire(
         self,
         timeout: float | None = None,
@@ -456,32 +490,11 @@ class RedisLock(utils.LockBase['RedisLock']):
                 self.holder_id,
                 holders,
             )
-            if holders is not None and self._holders_are_compatible(holders):
+            if self._resolve_lock_holders(
+                holders,
+                effective_fail_when_locked,
+            ):
                 return self
-            writer_is_elected: bool = (
-                holders is not None
-                and self.flags == constants.LockFlags.EXCLUSIVE
-                and self._writer_is_elected(holders)
-            )
-            if writer_is_elected:
-                self.writer_elected = True
-                if effective_fail_when_locked:
-                    self.release()
-                    raise exceptions.AlreadyLocked()
-                if holders is not None and not any(
-                    holder.mode is RedisLockMode.SHARED
-                    for holder in holders
-                ):
-                    self.mode = RedisLockMode.EXCLUSIVE
-                    return self
-                continue
-            if holders is None and self.writer_elected:
-                continue
-
-            self.release()
-            logger.debug('Redis lock %s released to retry', self.holder_id)
-            if effective_fail_when_locked:
-                raise exceptions.AlreadyLocked()
 
         self.release()
         raise exceptions.AlreadyLocked()

--- a/portalocker/redis.py
+++ b/portalocker/redis.py
@@ -422,7 +422,8 @@ class RedisLock(utils.LockBase['RedisLock']):
                 self.release()
                 raise exceptions.AlreadyLocked()
             if holders is not None and not any(
-                holder.mode is RedisLockMode.SHARED for holder in holders
+                holder.mode is RedisLockMode.SHARED
+                for holder in holders
             ):
                 self.mode = RedisLockMode.EXCLUSIVE
                 return True

--- a/portalocker_tests/test_redis.py
+++ b/portalocker_tests/test_redis.py
@@ -313,6 +313,14 @@ def test_redis_pending_writer_blocks_new_readers(
     writer_thread: threading.Thread = threading.Thread(target=acquire_writer)
     writer_thread.start()
     _wait_for_subscribers(reader, 2)
+    # Before its first complete holder sample a pending writer backs off by
+    # releasing its subscription, making it invisible to new readers. The
+    # reader-gating guarantee only holds once the writer is elected, so the
+    # test must synchronize on that state.
+    election_deadline: float = time.monotonic() + 30
+    while not writer.writer_elected and time.monotonic() < election_deadline:
+        time.sleep(0.001)
+    assert writer.writer_elected
 
     try:
         assert not writer_released.wait(timeout=0.4)
@@ -395,6 +403,13 @@ def test_redis_pending_writers_are_elected_by_holder_id(
     _wait_for_subscribers(reader, 2)
     second_thread.start()
     _wait_for_subscribers(reader, 3)
+    # An unelected writer backs off by dropping its subscription whenever a
+    # holder sample is incomplete, so the election order is only pinned down
+    # once the favored writer is actually elected while the reader holds on.
+    election_deadline: float = time.monotonic() + 30
+    while not first.writer_elected and time.monotonic() < election_deadline:
+        time.sleep(0.001)
+    assert first.writer_elected
 
     reader.release()
     acquired_deadline: float = time.monotonic() + 20

--- a/portalocker_tests/test_redis.py
+++ b/portalocker_tests/test_redis.py
@@ -196,6 +196,7 @@ def test_redis_shared_locks_coexist(
         first.release()
 
 
+@pytest.mark.timeout(180)
 @pytest.mark.parametrize(
     ('holder_flags', 'contender_flags'),
     [
@@ -264,6 +265,7 @@ def _wait_for_subscribers(
     raise AssertionError(f'never observed {expected} subscribers')
 
 
+@pytest.mark.timeout(180)
 def test_redis_pending_writer_blocks_new_readers(
     redis_connection: ConnectionFactory,
     monkeypatch: pytest.MonkeyPatch,
@@ -325,13 +327,14 @@ def test_redis_pending_writer_blocks_new_readers(
         assert late_reader.pubsub is None
     finally:
         reader.release()
-        writer_thread.join(timeout=15)
+        writer_thread.join(timeout=60)
         writer.release()
 
     assert not writer_thread.is_alive()
     assert not writer_errors
 
 
+@pytest.mark.timeout(180)
 def test_redis_pending_writers_are_elected_by_holder_id(
     redis_connection: ConnectionFactory,
     monkeypatch: pytest.MonkeyPatch,
@@ -402,10 +405,10 @@ def test_redis_pending_writers_are_elected_by_holder_id(
     assert acquired == ['first']
 
     first.release()
-    second_thread.join(timeout=15)
+    second_thread.join(timeout=60)
     assert acquired == ['first', 'second']
     second.release()
-    first_thread.join(timeout=1)
+    first_thread.join(timeout=10)
     assert not first_thread.is_alive()
     assert not second_thread.is_alive()
     assert not errors
@@ -1133,6 +1136,7 @@ def test_redis_check_or_kill_lock_always_closes_pubsub(
     assert calls.count('close') == 1
 
 
+@pytest.mark.timeout(60)
 def test_redis_acquire_fail_when_locked_fails_fast() -> None:
     """``fail_when_locked`` raises immediately when the holder is alive.
 

--- a/portalocker_tests/test_redis.py
+++ b/portalocker_tests/test_redis.py
@@ -244,6 +244,26 @@ def _ignore_stale_cleanup(
     pass
 
 
+def _wait_for_subscribers(
+    lock: redis.RedisLock,
+    expected: int,
+    timeout: float = 10,
+) -> None:
+    """Block until the lock channel has at least ``expected`` subscribers.
+
+    ``RedisLock.pubsub`` is assigned before SUBSCRIBE reaches the server,
+    so waiting for ``pubsub is not None`` does not guarantee that a waiter
+    participates in elections yet. Contention tests must synchronize on
+    the server-side subscriber count instead.
+    """
+    deadline: float = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if lock._get_subscriber_count(lock.get_connection()) >= expected:
+            return
+        time.sleep(0.001)
+    raise AssertionError(f'never observed {expected} subscribers')
+
+
 def test_redis_pending_writer_blocks_new_readers(
     redis_connection: ConnectionFactory,
     monkeypatch: pytest.MonkeyPatch,
@@ -290,10 +310,7 @@ def test_redis_pending_writer_blocks_new_readers(
     reader.acquire()
     writer_thread: threading.Thread = threading.Thread(target=acquire_writer)
     writer_thread.start()
-    deadline: float = time.monotonic() + 1
-    while writer.pubsub is None and time.monotonic() < deadline:
-        time.sleep(0.001)
-    assert writer.pubsub is not None
+    _wait_for_subscribers(reader, 2)
 
     try:
         assert not writer_released.wait(timeout=0.4)
@@ -372,15 +389,9 @@ def test_redis_pending_writers_are_elected_by_holder_id(
         args=(second, 'second'),
     )
     first_thread.start()
-    first_deadline: float = time.monotonic() + 2
-    while first.pubsub is None and time.monotonic() < first_deadline:
-        time.sleep(0.001)
-    assert first.pubsub is not None
+    _wait_for_subscribers(reader, 2)
     second_thread.start()
-    second_deadline: float = time.monotonic() + 2
-    while second.pubsub is None and time.monotonic() < second_deadline:
-        time.sleep(0.001)
-    assert second.pubsub is not None
+    _wait_for_subscribers(reader, 3)
 
     reader.release()
     acquired_deadline: float = time.monotonic() + 20

--- a/portalocker_tests/test_redis.py
+++ b/portalocker_tests/test_redis.py
@@ -236,6 +236,14 @@ def test_redis_incompatible_lock_modes_contend(
         holder.release()
 
 
+def _ignore_stale_cleanup(
+    lock: redis.RedisLock,
+    connection: client.Redis,
+    responding_holders: typing.Iterable[redis.RedisLockHolder],
+) -> None:
+    pass
+
+
 def test_redis_pending_writer_blocks_new_readers(
     redis_connection: ConnectionFactory,
     monkeypatch: pytest.MonkeyPatch,
@@ -253,6 +261,14 @@ def test_redis_pending_writer_blocks_new_readers(
         check_interval=0.02,
         unavailable_timeout=0.2,
     )
+    if isinstance(reader.connection, fakeredis.FakeStrictRedis):
+        # fakeredis does not implement CLIENT KILL. Stale-holder cleanup is
+        # covered independently; this test isolates writer gating.
+        monkeypatch.setattr(
+            redis.RedisLock,
+            '_kill_unavailable_locks',
+            _ignore_stale_cleanup,
+        )
     writer_errors: list[BaseException] = []
     writer_released: threading.Event = threading.Event()
     original_writer_release: typing.Callable[[], None] = writer.release
@@ -301,26 +317,20 @@ def test_redis_pending_writers_are_elected_by_holder_id(
     redis_connection: ConnectionFactory,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    def ignore_stale_cleanup(
-        lock: redis.RedisLock,
-        connection: client.Redis,
-        responding_holders: typing.Iterable[redis.RedisLockHolder],
-    ) -> None:
-        pass
-
-    # fakeredis does not implement CLIENT KILL. Stale-holder cleanup is
-    # covered independently; this test isolates writer election.
-    monkeypatch.setattr(
-        redis.RedisLock,
-        '_kill_unavailable_locks',
-        ignore_stale_cleanup,
-    )
     channel: str = str(random.random())
     reader: redis.RedisLock = redis.RedisLock(
         channel,
         connection=redis_connection(),
         flags=portalocker.LockFlags.SHARED,
     )
+    if isinstance(reader.connection, fakeredis.FakeStrictRedis):
+        # fakeredis does not implement CLIENT KILL. Stale-holder cleanup is
+        # covered independently; this test isolates writer election.
+        monkeypatch.setattr(
+            redis.RedisLock,
+            '_kill_unavailable_locks',
+            _ignore_stale_cleanup,
+        )
     first: redis.RedisLock = redis.RedisLock(
         channel,
         connection=redis_connection(),
@@ -1002,9 +1012,11 @@ def test_redis_acquire_fail_when_locked_fails_fast() -> None:
         server=server,
         decode_responses=True,
     )
-    contender_connection: fakeredis.FakeStrictRedis = fakeredis.FakeStrictRedis(
-        server=server,
-        decode_responses=True,
+    contender_connection: fakeredis.FakeStrictRedis = (
+        fakeredis.FakeStrictRedis(
+            server=server,
+            decode_responses=True,
+        )
     )
     channel: str = str(random.random())
     holder: redis.RedisLock = redis.RedisLock(

--- a/portalocker_tests/test_redis.py
+++ b/portalocker_tests/test_redis.py
@@ -254,12 +254,14 @@ def test_redis_pending_writer_blocks_new_readers(
         connection=redis_connection(),
         flags=portalocker.LockFlags.SHARED,
     )
+    # Timeouts are sized for heavily loaded CI runners; the assertions below
+    # never wait for these upper bounds on the happy path.
     writer: redis.RedisLock = redis.RedisLock(
         channel,
         connection=redis_connection(),
-        timeout=5,
+        timeout=30,
         check_interval=0.02,
-        unavailable_timeout=0.2,
+        unavailable_timeout=2,
     )
     if isinstance(reader.connection, fakeredis.FakeStrictRedis):
         # fakeredis does not implement CLIENT KILL. Stale-holder cleanup is
@@ -306,7 +308,7 @@ def test_redis_pending_writer_blocks_new_readers(
         assert late_reader.pubsub is None
     finally:
         reader.release()
-        writer_thread.join(timeout=3)
+        writer_thread.join(timeout=15)
         writer.release()
 
     assert not writer_thread.is_alive()
@@ -331,19 +333,22 @@ def test_redis_pending_writers_are_elected_by_holder_id(
             '_kill_unavailable_locks',
             _ignore_stale_cleanup,
         )
+    # The election result depends on every pending writer answering liveness
+    # pings in time, so the unavailable window has to absorb CI scheduling
+    # stalls; the happy path never waits for these upper bounds.
     first: redis.RedisLock = redis.RedisLock(
         channel,
         connection=redis_connection(),
-        timeout=10,
+        timeout=30,
         check_interval=0.02,
-        unavailable_timeout=1,
+        unavailable_timeout=5,
     )
     second: redis.RedisLock = redis.RedisLock(
         channel,
         connection=redis_connection(),
-        timeout=10,
+        timeout=30,
         check_interval=0.02,
-        unavailable_timeout=1,
+        unavailable_timeout=5,
     )
     first.holder_id = 'a-first-writer'
     second.holder_id = 'b-second-writer'
@@ -378,7 +383,7 @@ def test_redis_pending_writers_are_elected_by_holder_id(
     assert second.pubsub is not None
 
     reader.release()
-    acquired_deadline: float = time.monotonic() + 6
+    acquired_deadline: float = time.monotonic() + 20
     while not acquired and not errors and time.monotonic() < acquired_deadline:
         time.sleep(0.001)
     if errors:
@@ -386,13 +391,89 @@ def test_redis_pending_writers_are_elected_by_holder_id(
     assert acquired == ['first']
 
     first.release()
-    second_thread.join(timeout=4)
+    second_thread.join(timeout=15)
     assert acquired == ['first', 'second']
     second.release()
     first_thread.join(timeout=1)
     assert not first_thread.is_alive()
     assert not second_thread.is_alive()
     assert not errors
+
+
+def test_redis_elected_writer_waits_for_shared_holders() -> None:
+    lock: redis.RedisLock = redis.RedisLock(str(random.random()))
+    lock.holder_id = 'writer'
+    holders: list[redis.RedisLockHolder] = [
+        redis.RedisLockHolder(
+            holder_id=lock.holder_id,
+            mode=redis.RedisLockMode.PENDING,
+        ),
+        redis.RedisLockHolder(
+            holder_id='reader',
+            mode=redis.RedisLockMode.SHARED,
+        ),
+    ]
+
+    assert not lock._resolve_lock_holders(holders, fail_when_locked=False)
+    assert lock.writer_elected
+    assert lock.mode is redis.RedisLockMode.PENDING
+    assert not lock._resolve_lock_holders(None, fail_when_locked=False)
+
+
+def test_redis_elected_writer_reuses_subscription(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    connection: fakeredis.FakeStrictRedis = fakeredis.FakeStrictRedis(
+        server=fakeredis.FakeServer(),
+        decode_responses=True,
+    )
+    lock: redis.RedisLock = redis.RedisLock(
+        str(random.random()),
+        connection=connection,
+        check_interval=0.001,
+        timeout=1,
+    )
+    lock.holder_id = 'writer'
+    holders: list[redis.RedisLockHolder] = [
+        redis.RedisLockHolder(
+            holder_id=lock.holder_id,
+            mode=redis.RedisLockMode.PENDING,
+        ),
+        redis.RedisLockHolder(
+            holder_id='reader',
+            mode=redis.RedisLockMode.SHARED,
+        ),
+    ]
+    subscriber_counts: list[int] = [2, 1]
+    start_calls: list[client.Redis] = []
+    sentinel_pubsub: client.PubSub = typing.cast(
+        'client.PubSub',
+        object(),
+    )
+
+    def start_subscription(connection_: client.Redis) -> None:
+        start_calls.append(connection_)
+        lock.pubsub = sentinel_pubsub
+
+    def get_subscriber_count(connection_: client.Redis) -> int:
+        return subscriber_counts.pop(0)
+
+    def collect_lock_holders(
+        connection_: client.Redis,
+        expected_subscribers: int,
+        timeout: float,
+    ) -> list[redis.RedisLockHolder]:
+        return holders
+
+    monkeypatch.setattr(lock, '_start_subscription', start_subscription)
+    monkeypatch.setattr(lock, '_get_subscriber_count', get_subscriber_count)
+    monkeypatch.setattr(lock, '_collect_lock_holders', collect_lock_holders)
+
+    assert lock.acquire() is lock
+    assert start_calls == [connection]
+    assert lock.mode is redis.RedisLockMode.EXCLUSIVE
+    lock.pubsub = None
+    connection.close()
 
 
 @pytest.mark.parametrize('timeout', [None, 0, 0.001])
@@ -1024,12 +1105,16 @@ def test_redis_acquire_fail_when_locked_fails_fast() -> None:
         connection=holder_connection,
         thread_sleep_time=0.001,
     )
+    # The generous timeout is the point of the regression: failing fast must
+    # not depend on the timeout, so the elapsed assertion below proves the
+    # contender never polled anywhere near it even on slow CI runners.
     contender: redis.RedisLock = redis.RedisLock(
         channel,
         connection=contender_connection,
-        timeout=1,
+        timeout=30,
         fail_when_locked=True,
         thread_sleep_time=0.001,
+        unavailable_timeout=2,
     )
     holder.acquire()
 
@@ -1038,7 +1123,7 @@ def test_redis_acquire_fail_when_locked_fails_fast() -> None:
         contender.acquire()
     elapsed: float = time.monotonic() - start
 
-    assert elapsed < 0.5
+    assert elapsed < 10
     holder.release()
 
 

--- a/portalocker_tests/test_redis.py
+++ b/portalocker_tests/test_redis.py
@@ -9,7 +9,9 @@ server, mirroring real usage.
 
 import _thread
 import json
+import os
 import random
+import threading
 import time
 import typing
 
@@ -23,12 +25,100 @@ from portalocker import redis, utils
 ConnectionFactory = typing.Callable[[], client.Redis]
 
 
-def _live_redis_available() -> bool:
+def test_redis_lock_accepts_shared_flag() -> None:
+    lock: redis.RedisLock = redis.RedisLock(
+        'shared-channel',
+        flags=portalocker.LockFlags.SHARED,
+    )
+
+    assert lock.flags == portalocker.LockFlags.SHARED
+
+
+def test_redis_lock_uses_holder_specific_client_name() -> None:
+    lock: redis.RedisLock = redis.RedisLock('named-channel')
+
+    assert lock.client_name == f'named-channel-lock-{lock.holder_id}'
+    assert lock.legacy_client_name == 'named-channel-lock'
+
+
+def test_redis_lock_names_pubsub_connection(
+    redis_connection: ConnectionFactory,
+) -> None:
+    lock: redis.RedisLock = redis.RedisLock(
+        str(random.random()),
+        connection=redis_connection(),
+    )
+
+    lock.acquire()
     try:
-        client.Redis().ping()
+        connection: client.Redis = lock.get_connection()
+        matching_clients: list[dict[str, str]] = [
+            client_
+            for client_ in connection.client_list()
+            if client_.get('name') == lock.client_name
+        ]
+        assert len(matching_clients) == 1
+        if not isinstance(connection, fakeredis.FakeStrictRedis):
+            assert int(matching_clients[0]['sub']) == 1
+    finally:
+        lock.release()
+
+
+def test_live_redis_required_fails_when_server_is_unavailable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv('PORTALOCKER_REDIS_TESTS_REQUIRED', '1')
+
+    with pytest.raises(pytest.UsageError, match='required live Redis server'):
+        _ensure_live_redis_available(False)
+
+
+@pytest.mark.parametrize(
+    'flags',
+    [
+        portalocker.LockFlags(0),
+        portalocker.LockFlags.EXCLUSIVE | portalocker.LockFlags.SHARED,
+        portalocker.LockFlags.SHARED | portalocker.LockFlags.NON_BLOCKING,
+    ],
+)
+def test_redis_lock_rejects_invalid_flags(
+    flags: portalocker.LockFlags,
+) -> None:
+    with pytest.raises(ValueError, match='exactly one'):
+        redis.RedisLock('invalid-channel', flags=flags)
+
+
+def _live_redis_connection() -> client.Redis:
+    host: str = os.environ.get('REDIS_HOST', 'localhost')
+    port: int = int(os.environ.get('REDIS_PORT', '6379'))
+    return client.Redis(
+        host=host,
+        port=port,
+        decode_responses=True,
+    )
+
+
+def _live_redis_available() -> bool:
+    connection: client.Redis = _live_redis_connection()
+    try:
+        connection.ping()
     except (exceptions.ConnectionError, ConnectionRefusedError):
         return False
+    finally:
+        connection.close()
     return True
+
+
+def _ensure_live_redis_available(available: bool) -> None:
+    if available:
+        return
+    if os.environ.get('PORTALOCKER_REDIS_TESTS_REQUIRED') == '1':
+        raise pytest.UsageError(
+            'required live Redis server is unavailable at '
+            f'{os.environ.get("REDIS_HOST", "localhost")}:'
+            f'{os.environ.get("REDIS_PORT", "6379")}'
+        )
+    pytest.skip('no live redis server')
 
 
 _LIVE_REDIS: bool = _live_redis_available()
@@ -50,9 +140,8 @@ def set_redis_timeouts(monkeypatch: pytest.MonkeyPatch) -> None:
 def redis_connection(request: pytest.FixtureRequest) -> ConnectionFactory:
     """Yield a connection factory backed by fakeredis or a live server."""
     if request.param == 'live':
-        if not _LIVE_REDIS:
-            pytest.skip('no live redis server on localhost:6379')
-        return lambda: client.Redis(decode_responses=True)
+        _ensure_live_redis_available(_LIVE_REDIS)
+        return _live_redis_connection
 
     server: fakeredis.FakeServer = fakeredis.FakeServer()
     return lambda: fakeredis.FakeStrictRedis(
@@ -82,6 +171,218 @@ def test_redis_lock(redis_connection: ConnectionFactory) -> None:
         lock_a.release()
         if lock_a.connection is not None:
             lock_a.connection.close()
+
+
+def test_redis_shared_locks_coexist(
+    redis_connection: ConnectionFactory,
+) -> None:
+    channel: str = str(random.random())
+    first: redis.RedisLock = redis.RedisLock(
+        channel,
+        connection=redis_connection(),
+        flags=portalocker.LockFlags.SHARED,
+    )
+    second: redis.RedisLock = redis.RedisLock(
+        channel,
+        connection=redis_connection(),
+        flags=portalocker.LockFlags.SHARED,
+    )
+
+    try:
+        first.acquire()
+        second.acquire()
+    finally:
+        second.release()
+        first.release()
+
+
+@pytest.mark.parametrize(
+    ('holder_flags', 'contender_flags'),
+    [
+        (
+            portalocker.LockFlags.SHARED,
+            portalocker.LockFlags.EXCLUSIVE,
+        ),
+        (
+            portalocker.LockFlags.EXCLUSIVE,
+            portalocker.LockFlags.SHARED,
+        ),
+    ],
+)
+def test_redis_incompatible_lock_modes_contend(
+    redis_connection: ConnectionFactory,
+    holder_flags: portalocker.LockFlags,
+    contender_flags: portalocker.LockFlags,
+) -> None:
+    channel: str = str(random.random())
+    holder: redis.RedisLock = redis.RedisLock(
+        channel,
+        connection=redis_connection(),
+        flags=holder_flags,
+    )
+    contender: redis.RedisLock = redis.RedisLock(
+        channel,
+        connection=redis_connection(),
+        flags=contender_flags,
+        fail_when_locked=True,
+    )
+
+    holder.acquire()
+    try:
+        with pytest.raises(portalocker.AlreadyLocked):
+            contender.acquire()
+        assert contender.pubsub is None
+    finally:
+        holder.release()
+
+
+def test_redis_pending_writer_blocks_new_readers(
+    redis_connection: ConnectionFactory,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    channel: str = str(random.random())
+    reader: redis.RedisLock = redis.RedisLock(
+        channel,
+        connection=redis_connection(),
+        flags=portalocker.LockFlags.SHARED,
+    )
+    writer: redis.RedisLock = redis.RedisLock(
+        channel,
+        connection=redis_connection(),
+        timeout=5,
+        check_interval=0.02,
+        unavailable_timeout=0.2,
+    )
+    writer_errors: list[BaseException] = []
+    writer_released: threading.Event = threading.Event()
+    original_writer_release: typing.Callable[[], None] = writer.release
+
+    def record_writer_release() -> None:
+        original_writer_release()
+        writer_released.set()
+
+    monkeypatch.setattr(writer, 'release', record_writer_release)
+
+    def acquire_writer() -> None:
+        try:
+            writer.acquire()
+        except BaseException as exception:  # pragma: no cover
+            writer_errors.append(exception)
+
+    reader.acquire()
+    writer_thread: threading.Thread = threading.Thread(target=acquire_writer)
+    writer_thread.start()
+    deadline: float = time.monotonic() + 1
+    while writer.pubsub is None and time.monotonic() < deadline:
+        time.sleep(0.001)
+    assert writer.pubsub is not None
+
+    try:
+        assert not writer_released.wait(timeout=0.4)
+        late_reader: redis.RedisLock = redis.RedisLock(
+            channel,
+            connection=redis_connection(),
+            flags=portalocker.LockFlags.SHARED,
+            fail_when_locked=True,
+        )
+        with pytest.raises(portalocker.AlreadyLocked):
+            late_reader.acquire()
+        assert late_reader.pubsub is None
+    finally:
+        reader.release()
+        writer_thread.join(timeout=3)
+        writer.release()
+
+    assert not writer_thread.is_alive()
+    assert not writer_errors
+
+
+def test_redis_pending_writers_are_elected_by_holder_id(
+    redis_connection: ConnectionFactory,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def ignore_stale_cleanup(
+        lock: redis.RedisLock,
+        connection: client.Redis,
+        responding_holders: typing.Iterable[redis.RedisLockHolder],
+    ) -> None:
+        pass
+
+    # fakeredis does not implement CLIENT KILL. Stale-holder cleanup is
+    # covered independently; this test isolates writer election.
+    monkeypatch.setattr(
+        redis.RedisLock,
+        '_kill_unavailable_locks',
+        ignore_stale_cleanup,
+    )
+    channel: str = str(random.random())
+    reader: redis.RedisLock = redis.RedisLock(
+        channel,
+        connection=redis_connection(),
+        flags=portalocker.LockFlags.SHARED,
+    )
+    first: redis.RedisLock = redis.RedisLock(
+        channel,
+        connection=redis_connection(),
+        timeout=10,
+        check_interval=0.02,
+        unavailable_timeout=1,
+    )
+    second: redis.RedisLock = redis.RedisLock(
+        channel,
+        connection=redis_connection(),
+        timeout=10,
+        check_interval=0.02,
+        unavailable_timeout=1,
+    )
+    first.holder_id = 'a-first-writer'
+    second.holder_id = 'b-second-writer'
+    acquired: list[str] = []
+    errors: list[BaseException] = []
+
+    def acquire(lock: redis.RedisLock, name: str) -> None:
+        try:
+            lock.acquire()
+            acquired.append(name)
+        except BaseException as exception:  # pragma: no cover
+            errors.append(exception)
+
+    reader.acquire()
+    first_thread: threading.Thread = threading.Thread(
+        target=acquire,
+        args=(first, 'first'),
+    )
+    second_thread: threading.Thread = threading.Thread(
+        target=acquire,
+        args=(second, 'second'),
+    )
+    first_thread.start()
+    first_deadline: float = time.monotonic() + 2
+    while first.pubsub is None and time.monotonic() < first_deadline:
+        time.sleep(0.001)
+    assert first.pubsub is not None
+    second_thread.start()
+    second_deadline: float = time.monotonic() + 2
+    while second.pubsub is None and time.monotonic() < second_deadline:
+        time.sleep(0.001)
+    assert second.pubsub is not None
+
+    reader.release()
+    acquired_deadline: float = time.monotonic() + 6
+    while not acquired and not errors and time.monotonic() < acquired_deadline:
+        time.sleep(0.001)
+    if errors:
+        raise errors[0]
+    assert acquired == ['first']
+
+    first.release()
+    second_thread.join(timeout=4)
+    assert acquired == ['first', 'second']
+    second.release()
+    first_thread.join(timeout=1)
+    assert not first_thread.is_alive()
+    assert not second_thread.is_alive()
+    assert not errors
 
 
 @pytest.mark.parametrize('timeout', [None, 0, 0.001])
@@ -177,7 +478,7 @@ def test_redis_channel_handler(redis_connection: ConnectionFactory) -> None:
         while (message := pubsub.get_message(timeout=0.1)) is not None:
             assert message.get('type') != 'message'
 
-        # A ping publishes a pong (timestamp) on the response channel.
+        # A ping publishes holder identity and mode on the response channel.
         lock.channel_handler(
             {
                 'type': 'message',
@@ -196,12 +497,200 @@ def test_redis_channel_handler(redis_connection: ConnectionFactory) -> None:
                 pong = message
                 break
         assert pong is not None
-        pong_data: typing.Any = pong['data']
-        assert pong_data is not None
-        assert float(pong_data) > 0
+        pong_raw_data: typing.Any = pong['data']
+        assert isinstance(pong_raw_data, (str, bytes, bytearray))
+        pong_data: dict[str, typing.Any] = json.loads(pong_raw_data)
+        assert pong_data == {
+            'holder_id': lock.holder_id,
+            'mode': 'exclusive',
+            'protocol': 1,
+        }
         pubsub.close()
     finally:
         lock.release()
+
+
+@pytest.mark.parametrize(
+    'data',
+    [
+        'not-json',
+        json.dumps([]),
+        json.dumps({}),
+        json.dumps({'response_channel': 123}),
+    ],
+)
+def test_redis_channel_handler_ignores_invalid_messages(
+    data: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    connection: fakeredis.FakeStrictRedis = fakeredis.FakeStrictRedis(
+        server=fakeredis.FakeServer(),
+        decode_responses=True,
+    )
+    lock: redis.RedisLock = redis.RedisLock(
+        str(random.random()),
+        connection=connection,
+    )
+    published: list[tuple[str, str]] = []
+    monkeypatch.setattr(
+        connection,
+        'publish',
+        lambda channel, message: published.append((channel, message)),
+    )
+
+    lock.channel_handler({'type': 'message', 'data': data})
+
+    assert published == []
+
+
+def test_redis_parse_legacy_response_as_exclusive() -> None:
+    lock: redis.RedisLock = redis.RedisLock(str(random.random()))
+
+    holder: redis.RedisLockHolder = lock._parse_lock_response('123.45', 7)
+
+    assert holder == redis.RedisLockHolder(
+        holder_id='legacy-7',
+        mode=redis.RedisLockMode.EXCLUSIVE,
+        legacy=True,
+    )
+
+
+@pytest.mark.parametrize(
+    'response',
+    [
+        json.dumps(
+            {
+                'holder_id': 123,
+                'mode': 'shared',
+                'protocol': 1,
+            }
+        ),
+        json.dumps(
+            {
+                'holder_id': 'holder',
+                'mode': 123,
+                'protocol': 1,
+            }
+        ),
+        json.dumps(
+            {
+                'holder_id': 'holder',
+                'mode': 'unknown',
+                'protocol': 1,
+            }
+        ),
+        json.dumps(
+            {
+                'holder_id': 'holder',
+                'mode': 'shared',
+                'protocol': 2,
+            }
+        ),
+    ],
+)
+def test_redis_parse_unknown_response_as_legacy(response: str) -> None:
+    lock: redis.RedisLock = redis.RedisLock(str(random.random()))
+
+    holder: redis.RedisLockHolder = lock._parse_lock_response(response, 0)
+
+    assert holder.mode is redis.RedisLockMode.EXCLUSIVE
+    assert holder.legacy
+
+
+def test_redis_shared_lock_blocks_on_legacy_holder(
+    redis_connection: ConnectionFactory,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    channel: str = str(random.random())
+    legacy_holder: redis.RedisLock = redis.RedisLock(
+        channel,
+        connection=redis_connection(),
+    )
+
+    def legacy_channel_handler(message: dict[str, str]) -> None:
+        if message.get('type') != 'message':  # pragma: no cover
+            return
+        data: dict[str, str] = json.loads(message['data'])
+        connection: client.Redis = legacy_holder.get_connection()
+        connection.publish(data['response_channel'], str(time.time()))
+
+    monkeypatch.setattr(
+        legacy_holder,
+        'channel_handler',
+        legacy_channel_handler,
+    )
+    shared_contender: redis.RedisLock = redis.RedisLock(
+        channel,
+        connection=redis_connection(),
+        flags=portalocker.LockFlags.SHARED,
+        fail_when_locked=True,
+    )
+
+    legacy_holder.acquire()
+    try:
+        with pytest.raises(portalocker.AlreadyLocked):
+            shared_contender.acquire()
+    finally:
+        legacy_holder.release()
+
+
+def test_legacy_probe_recognizes_new_shared_holder(
+    redis_connection: ConnectionFactory,
+) -> None:
+    channel: str = str(random.random())
+    shared_holder: redis.RedisLock = redis.RedisLock(
+        channel,
+        connection=redis_connection(),
+        flags=portalocker.LockFlags.SHARED,
+    )
+    legacy_probe: redis.RedisLock = redis.RedisLock(
+        channel,
+        connection=redis_connection(),
+    )
+
+    shared_holder.acquire()
+    try:
+        connection: client.Redis = legacy_probe.get_connection()
+        assert legacy_probe.check_or_kill_lock(connection, timeout=0.2)
+    finally:
+        shared_holder.release()
+
+
+def test_live_redis_reaps_unresponsive_shared_holder(
+    redis_connection: ConnectionFactory,
+) -> None:
+    holder_connection: client.Redis = redis_connection()
+    if isinstance(holder_connection, fakeredis.FakeStrictRedis):
+        pytest.skip('fakeredis does not implement CLIENT KILL')
+    contender_connection: client.Redis = redis_connection()
+    channel: str = str(random.random())
+    holder: redis.RedisLock = redis.RedisLock(
+        channel,
+        connection=holder_connection,
+        flags=portalocker.LockFlags.SHARED,
+        unavailable_timeout=0.2,
+    )
+    contender: redis.RedisLock = redis.RedisLock(
+        channel,
+        connection=contender_connection,
+        timeout=2,
+        check_interval=0.02,
+        unavailable_timeout=0.2,
+    )
+
+    holder.acquire()
+    assert holder.thread is not None
+    holder.thread.stop()
+    holder.thread.join()
+    holder.thread = None
+    try:
+        contender.acquire()
+        assert contender.mode is redis.RedisLockMode.EXCLUSIVE
+    finally:
+        contender.release()
+        holder.release()
+        holder_connection.close()
+        contender_connection.close()
 
 
 class _SilentPubSub:
@@ -215,6 +704,121 @@ class _SilentPubSub:
 
     def close(self) -> None:
         pass
+
+
+class _ResponsePubSub:
+    def __init__(
+        self,
+        responses: list[str],
+        confirmations: list[dict[str, typing.Any] | None] | None = None,
+    ) -> None:
+        self._responses: list[str] = responses
+        self._confirmations: list[dict[str, typing.Any] | None] = (
+            confirmations
+            if confirmations is not None
+            else [{'type': 'subscribe'}]
+        )
+
+    def subscribe(self, *channels: str) -> None:
+        pass
+
+    def get_message(self, timeout: float) -> dict[str, typing.Any] | None:
+        if self._confirmations:
+            return self._confirmations.pop(0)
+        if self._responses:
+            return {'type': 'message', 'data': self._responses.pop(0)}
+        return None
+
+    def close(self) -> None:
+        pass
+
+
+@pytest.mark.parametrize(
+    'confirmations',
+    [
+        [None],
+        [{'type': 'message'}, {'type': 'subscribe'}],
+    ],
+)
+def test_redis_collect_holders_tolerates_confirmation_delays(
+    confirmations: list[dict[str, typing.Any] | None],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    connection: fakeredis.FakeStrictRedis = fakeredis.FakeStrictRedis(
+        server=fakeredis.FakeServer(),
+        decode_responses=True,
+    )
+    lock: redis.RedisLock = redis.RedisLock(
+        str(random.random()),
+        connection=connection,
+        thread_sleep_time=0.001,
+    )
+    pubsub: _ResponsePubSub = _ResponsePubSub(
+        [],
+        confirmations=confirmations,
+    )
+    monkeypatch.setattr(lock, '_get_pubsub', lambda connection: pubsub)
+    monkeypatch.setattr(lock, '_get_subscriber_count', lambda connection: 0)
+    monkeypatch.setattr(connection, 'publish', lambda channel, message: 0)
+
+    holders: list[redis.RedisLockHolder] | None = lock._collect_lock_holders(
+        connection,
+        expected_subscribers=0,
+        timeout=0.01,
+    )
+
+    assert holders == []
+
+
+def test_redis_collect_holders_kills_only_unresponsive_holder(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    connection: fakeredis.FakeStrictRedis = fakeredis.FakeStrictRedis(
+        server=fakeredis.FakeServer(),
+        decode_responses=True,
+    )
+    lock: redis.RedisLock = redis.RedisLock(
+        'stale-channel',
+        connection=connection,
+        thread_sleep_time=0.001,
+    )
+    response: str = json.dumps(
+        {
+            'holder_id': 'responding',
+            'mode': 'shared',
+            'protocol': 1,
+        }
+    )
+    pubsub: _ResponsePubSub = _ResponsePubSub([response])
+    killed: list[str | None] = []
+    monkeypatch.setattr(lock, '_get_pubsub', lambda connection: pubsub)
+    monkeypatch.setattr(lock, '_get_subscriber_count', lambda connection: 2)
+    monkeypatch.setattr(connection, 'publish', lambda channel, message: 2)
+    monkeypatch.setattr(
+        connection,
+        'client_list',
+        lambda: [
+            {
+                'id': 'responding-client',
+                'name': 'stale-channel-lock-responding',
+            },
+            {'id': 'stale-client', 'name': 'stale-channel-lock-stale'},
+        ],
+    )
+    monkeypatch.setattr(
+        connection,
+        'client_kill_filter',
+        lambda client_id: killed.append(client_id),
+    )
+
+    holders: list[redis.RedisLockHolder] | None = lock._collect_lock_holders(
+        connection,
+        expected_subscribers=2,
+        timeout=0.01,
+    )
+
+    assert holders is None
+    assert killed == ['stale-client']
 
 
 def test_redis_check_or_kill_lock_kills_unresponsive_client(
@@ -388,41 +992,42 @@ def test_redis_check_or_kill_lock_always_closes_pubsub(
     assert calls.count('close') == 1
 
 
-def test_redis_acquire_fail_when_locked_fails_fast(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
+def test_redis_acquire_fail_when_locked_fails_fast() -> None:
     """``fail_when_locked`` raises immediately when the holder is alive.
 
-    It must not keep polling until the timeout expires. ``check_or_kill_lock``
-    is stubbed to report the holder alive and is expected to be consulted
-    exactly once before ``AlreadyLocked`` is raised.
+    It must not keep polling until the timeout expires.
     """
-    connection: fakeredis.FakeStrictRedis = fakeredis.FakeStrictRedis(
-        server=fakeredis.FakeServer(),
+    server: fakeredis.FakeServer = fakeredis.FakeServer()
+    holder_connection: fakeredis.FakeStrictRedis = fakeredis.FakeStrictRedis(
+        server=server,
         decode_responses=True,
     )
-    lock: redis.RedisLock = redis.RedisLock(
-        str(random.random()),
-        connection=connection,
+    contender_connection: fakeredis.FakeStrictRedis = fakeredis.FakeStrictRedis(
+        server=server,
+        decode_responses=True,
+    )
+    channel: str = str(random.random())
+    holder: redis.RedisLock = redis.RedisLock(
+        channel,
+        connection=holder_connection,
         thread_sleep_time=0.001,
     )
-    calls: list[float] = []
-
-    def check_or_kill_lock(conn: client.Redis, timeout: float) -> bool:
-        calls.append(timeout)
-        return True
-
-    monkeypatch.setattr(lock, '_get_subscriber_count', lambda conn: 1)
-    monkeypatch.setattr(lock, 'check_or_kill_lock', check_or_kill_lock)
+    contender: redis.RedisLock = redis.RedisLock(
+        channel,
+        connection=contender_connection,
+        timeout=1,
+        fail_when_locked=True,
+        thread_sleep_time=0.001,
+    )
+    holder.acquire()
 
     start: float = time.monotonic()
     with pytest.raises(portalocker.AlreadyLocked):
-        lock.acquire(timeout=1, fail_when_locked=True)
+        contender.acquire()
     elapsed: float = time.monotonic() - start
 
-    # Raised after a single liveness check, not after polling the timeout.
-    assert calls == [lock.unavailable_timeout]
     assert elapsed < 0.5
+    holder.release()
 
 
 def test_redis_release_closes_auto_created_connection(
@@ -475,6 +1080,12 @@ class _SubscribeError(Exception):
 
 class _BoomPubSub:
     """Pubsub whose ``subscribe`` always raises."""
+
+    def execute_command(self, *args: typing.Any) -> None:
+        pass
+
+    def parse_response(self) -> None:
+        pass
 
     def subscribe(self, **channels: typing.Any) -> None:
         raise _SubscribeError('subscribe failed')

--- a/portalocker_tests/test_redis.py
+++ b/portalocker_tests/test_redis.py
@@ -419,6 +419,13 @@ def test_redis_elected_writer_waits_for_shared_holders() -> None:
     assert lock.mode is redis.RedisLockMode.PENDING
     assert not lock._resolve_lock_holders(None, fail_when_locked=False)
 
+    # Once the last shared holder is gone the elected writer acquires. In
+    # the integration tests this path races the subscribers==1 fast path,
+    # so it has to be covered deterministically here.
+    assert lock._resolve_lock_holders([holders[0]], fail_when_locked=False)
+    resolved_mode: redis.RedisLockMode = lock.mode
+    assert resolved_mode is redis.RedisLockMode.EXCLUSIVE
+
 
 def test_redis_elected_writer_reuses_subscription(
     monkeypatch: pytest.MonkeyPatch,
@@ -859,6 +866,38 @@ def test_redis_collect_holders_tolerates_confirmation_delays(
     )
 
     assert holders == []
+
+
+def test_redis_collect_holders_detects_subscriber_churn(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A holder set that changes mid-probe invalidates the sample.
+
+    In the integration tests this only happens when a competing waiter
+    resubscribes at exactly the wrong moment, so it has to be covered
+    deterministically here.
+    """
+    connection: fakeredis.FakeStrictRedis = fakeredis.FakeStrictRedis(
+        server=fakeredis.FakeServer(),
+        decode_responses=True,
+    )
+    lock: redis.RedisLock = redis.RedisLock(
+        str(random.random()),
+        connection=connection,
+        thread_sleep_time=0.001,
+    )
+    pubsub: _ResponsePubSub = _ResponsePubSub([])
+    monkeypatch.setattr(lock, '_get_pubsub', lambda connection: pubsub)
+    monkeypatch.setattr(lock, '_get_subscriber_count', lambda connection: 1)
+    monkeypatch.setattr(connection, 'publish', lambda channel, message: 0)
+
+    holders: list[redis.RedisLockHolder] | None = lock._collect_lock_holders(
+        connection,
+        expected_subscribers=2,
+        timeout=0.01,
+    )
+
+    assert holders is None
 
 
 def test_redis_collect_holders_kills_only_unresponsive_holder(

--- a/tox.toml
+++ b/tox.toml
@@ -10,9 +10,25 @@ skip_missing_interpreters = true
 
 [env_run_base]
 labels = ['test']
-pass_env = ['FORCE_COLOR', 'REDIS_HOST']
+pass_env = ['FORCE_COLOR', 'REDIS_HOST', 'REDIS_PORT']
 extras = ['tests']
 commands = [['pytest', { replace = 'posargs', extend = true }]]
+
+[env.redis-live]
+labels = ['test']
+description = 'RedisLock tests against a required live Redis server'
+pass_env = ['FORCE_COLOR', 'REDIS_HOST', 'REDIS_PORT']
+set_env = { PORTALOCKER_REDIS_TESTS_REQUIRED = '1' }
+extras = ['tests']
+commands = [
+    [
+        'pytest',
+        '--no-cov',
+        'portalocker_tests/test_redis.py',
+        'portalocker_tests/test_redis_random_sleep.py',
+        { replace = 'posargs', extend = true },
+    ],
+]
 
 [env.win32]
 labels = ['test']


### PR DESCRIPTION
## Summary

- add opt-in shared Redis locks through `LockFlags.SHARED`
- prevent writer starvation with deterministic pending-writer election while preserving mixed-version safety
- identify heartbeat holders individually so stale Pub/Sub clients can be reaped without evicting responsive readers
- document shared-lock usage and add an optional `tox -e redis-live` environment

## Why

`RedisLock` previously treated every subscriber as an exclusive holder. That made it unsuitable as an NFS-safe replacement for workflows such as parallel compilation that require multiple concurrent readers.

The heartbeat protocol now communicates holder identity and mode. Legacy timestamp responses remain exclusive, so rolling upgrades fail safely rather than allowing incompatible overlap.

## User impact

Existing callers retain exclusive behavior by default. Callers can request concurrent readers with:

```python
portalocker.RedisLock(channel, flags=portalocker.LockFlags.SHARED)
```

Waiting writers gate later readers, avoiding writer starvation.

## Validation

- `uv run pytest -q` — passed with 100% coverage
- `REDIS_PORT=6399 uv run tox -e redis-live` — 74 passed, 1 expected fakeredis-only skip; no live-server skips
- live deterministic writer-election regression repeated 10 times
- `uv run mypy --show-error-codes --no-color-output`
- `uv run basedpyright`
- `uv run pyrefly check --output-format min-text --summary=none --color never`
- `uv run ty check`
- `uv run tox -e codespell`
- `uv run tox -e docs`

Closes #124