### PR TITLE
Restore CI on master: static test matrix, floating-linter compatibility

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,13 +37,11 @@ jobs:
     steps:
       - name: Generate Matrix for Tests
         id: generate-matrix
-        uses: coactions/dynamic-matrix@v4
-        with:
-          platforms: 'linux,macos,windows'
-          min_python: '3.9'
-          linux: full
-          windows: full
-          macos: full
+        # coactions/dynamic-matrix no longer builds on current runner images
+        # (its pinned cffi cannot compile under the bundled Python), so the
+        # matrix that it used to derive is pinned statically here.
+        run: |
+          echo 'matrix={"os":["ubuntu-latest","macos-latest","windows-latest"],"python_version":["3.9","3.10","3.11","3.12"]}' >> "$GITHUB_OUTPUT"
 
   # Job: Perform static type checking across the generated matrix.
   type_checking:

--- a/portalocker/exceptions.py
+++ b/portalocker/exceptions.py
@@ -12,7 +12,7 @@ class BaseLockException(Exception):  # noqa: N818
     def __init__(
         self,
         *args: typing.Any,
-        fh: typing.Union[types.IO, None, int, types.HasFileno] = None,
+        fh: typing.Union[types.IO, int, types.HasFileno, None] = None,
         **kwargs: typing.Any,
     ) -> None:
         self.fh = fh

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -138,6 +138,11 @@ ignore = [
     'PC111', # no blacken-docs because markdown has no code
     'PC140', # manual typecheck pre-commit hooks
     'PC170', # no pygrep-hooks because no rST
+    'PC180', # no markdown formatter on this legacy branch
+    'PC192', # legacy ruff pre-commit hook name is frozen on this branch
+    'PC902', # no custom pre-commit CI autofix message
+    'PC903', # no pre-commit CI schedule
+    'PP304', # pytest log level is not pinned on this legacy branch
     'PY005',  # Tests folder is not named tests
     'PY006', # pre-commit should not be used
     'PY007', # tox configured in tox.toml


### PR DESCRIPTION
Master's CI has been failing independently of any repository change, which blocked validating dependabot PRs (#112, #127):

- **Generate Test Matrix**: `coactions/dynamic-matrix` no longer builds on current runner images (its pinned `cffi` cannot compile under the bundled Python), failing matrix generation and skipping every test and type job. The matrix it used to derive is now pinned statically, with runner labels updated to currently supported images.
- **repo-review**: the action installs its `sp-repo-review` rule plugins unpinned, so newly added pre-commit/pytest style rules started failing this frozen branch. Those rules are exempted here; the 4.0.0 modernization replaces the affected tooling wholesale.
- **ruff**: the lint workflow installs ruff unpinned and 0.16 added RUF036, which rejects `None` in the middle of a type union (`portalocker/exceptions.py`). Reordered.

The branch CI run for this exact tree is fully green: all 24 test/type matrix jobs, lint, docs and repo-review.