### PR TITLE
Restore the AppVeyor build for the 4.0 layout

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,26 @@
+# What Python version is installed where:
+# http://www.appveyor.com/docs/installed-software#python
+
+image:
+  - Visual Studio 2022
+
+environment:
+  # The image's default Python on PATH is 32-bit; packages without win32
+  # wheels would fall back to failing source builds. Managed uv
+  # interpreters are always x64 and independent of the image.
+  UV_PYTHON_PREFERENCE: only-managed
+  matrix:
+  - TOXENV: py310
+  - TOXENV: py311
+  - TOXENV: py312
+  - TOXENV: py313
+  - TOXENV: py314
+
+install:
+  - powershell -ExecutionPolicy ByPass -c "irm https://astral.sh/uv/install.ps1 | iex"
+
+build: false  # Not a C# project, build stuff at the test step instead.
+
+test_script:
+  - dir
+  - C:\Users\appveyor\.local\bin\uvx.exe tox


### PR DESCRIPTION
The 4.0.0 modernization dropped `appveyor.yml`, but the AppVeyor project kept building every branch and PR with its detect-a-project fallback, stamping a permanent failure status on everything.

This restores a real build: the supported CPython tox environments (py310–py314) on uv-managed 64-bit interpreters (`UV_PYTHON_PREFERENCE: only-managed`, since the image's default PATH Python is 32-bit and packages without win32 wheels fail their source builds).

The AppVeyor build for this branch is green: https://ci.appveyor.com/project/WoLpH/portalocker/history (branch `fix/appveyor-develop`, all five environments passing).