### PR TITLE
Fix the AppVeyor build: 64-bit interpreters, env-local pinned pyright

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,6 +5,10 @@ image:
   - Visual Studio 2022
 
 environment:
+  # The image's default Python on PATH is 32-bit; packages such as
+  # cryptography no longer ship win32 wheels, so dependency installs fall
+  # back to source builds and fail. Managed interpreters are always x64.
+  UV_PYTHON_PREFERENCE: only-managed
   matrix:
   - TOXENV: py39
   - TOXENV: py310

--- a/tox.toml
+++ b/tox.toml
@@ -19,6 +19,9 @@ skip_missing_interpreters = true
 [env_run_base]
 labels = ['python']
 pass_env = ['FORCE_COLOR']
+# pyright is not part of the package extras; CI environments without a
+# globally installed pyright (e.g. AppVeyor) need it inside the env.
+deps = ['pyright']
 commands = [
     [
         'mypy',

--- a/tox.toml
+++ b/tox.toml
@@ -21,7 +21,9 @@ labels = ['python']
 pass_env = ['FORCE_COLOR']
 # pyright is not part of the package extras; CI environments without a
 # globally installed pyright (e.g. AppVeyor) need it inside the env.
-deps = ['pyright']
+# Pinned to the version in uv.lock: newer releases add deprecation
+# diagnostics that this frozen branch does not chase.
+deps = ['pyright==1.1.402']
 commands = [
     [
         'mypy',


### PR DESCRIPTION
AppVeyor has been failing every build for months. Three independent causes:

- The image's default PATH Python is 32-bit, so uv resolved every tox environment as win32, where `cryptography` (pulled in through `types-redis`) ships no wheel and fails its Rust source build for lack of OpenSSL. `UV_PYTHON_PREFERENCE: only-managed` switches to uv-managed interpreters, which are always x64 and independent of the image.
- The pyXX tox environments invoke `pyright` as an allowlisted external, which only works where CI installs it globally (the GitHub jobs do via `uv sync`; AppVeyor does not). It is now installed into the environments.
- Unpinned, that dep floated to pyright 1.1.411, which adds deprecation diagnostics (argparse.FileType, contextmanager return annotations) that this frozen branch does not chase. Pinned to 1.1.402, the version in uv.lock that the GitHub jobs already validate with.

The AppVeyor build for this exact branch is green: all five environments (py39–py313) run mypy, pyright and the full pytest suite.